### PR TITLE
feat(i18n): setup i18next with expo-localization

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,15 @@
+import './lib/i18n';
+
 import { StatusBar } from 'expo-status-bar';
 import { StyleSheet, Text, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 export default function App() {
+  const { t } = useTranslation();
+
   return (
     <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
+      <Text>{t('home.welcome')}</Text>
       <StatusBar style="auto" />
     </View>
   );

--- a/app.json
+++ b/app.json
@@ -25,6 +25,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "expo-localization"
+    ]
   }
 }

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -1,0 +1,20 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import { getLocales } from 'expo-localization';
+
+import fr from './locales/fr.json';
+
+const deviceLanguage = getLocales()[0]?.languageCode ?? 'fr';
+
+i18n.use(initReactI18next).init({
+  resources: {
+    fr: { translation: fr },
+  },
+  lng: deviceLanguage,
+  fallbackLng: 'fr',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -1,0 +1,54 @@
+{
+  "common": {
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "delete": "Supprimer",
+    "confirm": "Confirmer",
+    "loading": "Chargement...",
+    "error": "Une erreur est survenue",
+    "retry": "Réessayer",
+    "search": "Rechercher",
+    "add": "Ajouter",
+    "edit": "Modifier",
+    "back": "Retour",
+    "close": "Fermer"
+  },
+  "tabs": {
+    "home": "Accueil",
+    "stock": "Stock",
+    "add": "Ajouter",
+    "recipes": "Recettes",
+    "settings": "Réglages"
+  },
+  "home": {
+    "title": "Accueil",
+    "welcome": "Bienvenue sur Fridgy",
+    "emptyState": "Commencez par ajouter des produits à votre stock"
+  },
+  "stock": {
+    "title": "Mon stock",
+    "emptyState": "Votre stock est vide",
+    "addProduct": "Ajouter un produit",
+    "expiringProducts": "Produits bientôt périmés"
+  },
+  "add": {
+    "title": "Ajouter",
+    "scan": "Scanner un code-barres",
+    "scanReceipt": "Scanner un ticket de caisse",
+    "manual": "Ajouter manuellement"
+  },
+  "recipes": {
+    "title": "Recettes",
+    "emptyState": "Aucune recette trouvée",
+    "search": "Rechercher une recette",
+    "ingredients": "Ingrédients",
+    "steps": "Étapes"
+  },
+  "settings": {
+    "title": "Réglages",
+    "language": "Langue",
+    "notifications": "Notifications",
+    "about": "À propos",
+    "logout": "Se déconnecter"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "expo": "~54.0.33",
+        "expo-localization": "~17.0.8",
         "expo-status-bar": "~3.0.9",
+        "i18next": "^25.8.12",
         "react": "19.1.0",
+        "react-i18next": "^16.5.4",
         "react-native": "0.81.5"
       },
       "devDependencies": {
@@ -6926,6 +6929,19 @@
         }
       }
     },
+    "node_modules/expo-localization": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-localization/-/expo-localization-17.0.8.tgz",
+      "integrity": "sha512-UrdwklZBDJ+t+ZszMMiE0SXZ2eJxcquCuQcl6EvGHM9K+e6YqKVRQ+w8qE+iIB3H75v2RJy6MHAaLK+Mqeo04g==",
+      "license": "MIT",
+      "dependencies": {
+        "rtl-detect": "^1.0.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "3.0.24",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
@@ -8096,6 +8112,15 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -8175,6 +8200,37 @@
       "peer": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.8.12",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.12.tgz",
+      "integrity": "sha512-hw59RF5QaH9i3l47hTXjeLLtzgVO8OtznlTJZbulmaLbz+itA1hIKWHTEiajY9W2SNPzvL8U5nTBVt7SsOGNRA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -13175,6 +13231,33 @@
         "ws": "^7"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.5.4.tgz",
+      "integrity": "sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 25.6.2",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -13653,6 +13736,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/rtl-detect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rtl-detect/-/rtl-detect-1.1.2.tgz",
+      "integrity": "sha512-PGMBq03+TTG/p/cRB7HCLKJ1MgDIi07+QU1faSjiYRfmY5UsAttV9Hs08jDAHVwcOwmVLcSJkpwyfXszVjWfIQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -14909,7 +14998,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15099,6 +15188,15 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -15156,6 +15254,15 @@
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
   },
   "dependencies": {
     "expo": "~54.0.33",
+    "expo-localization": "~17.0.8",
     "expo-status-bar": "~3.0.9",
+    "i18next": "^25.8.12",
     "react": "19.1.0",
+    "react-i18next": "^16.5.4",
     "react-native": "0.81.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Install `i18next`, `react-i18next`, and `expo-localization`
- Configure i18n with automatic locale detection and French fallback
- Add base French translation keys for all main screens (home, stock, add, recipes, settings) and common UI strings
- Wire up `App.tsx` with `useTranslation()` hook as demo usage

## Test plan
- [ ] `npx tsc --noEmit` passes (no new errors)
- [ ] `npm run lint` passes (no new errors)
- [ ] `npm test` passes
- [ ] `t('clé')` returns French translations correctly

Refs #4