### PR TITLE
feat(scanning): barcode scan + Open Food Facts lookup (#9)

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,14 @@
     },
     "plugins": [
       "expo-localization",
-      "expo-router"
+      "expo-router",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Fridgy a besoin de la caméra pour scanner les codes-barres.",
+          "microphonePermission": false
+        }
+      ]
     ]
   }
 }

--- a/app/(tabs)/add.tsx
+++ b/app/(tabs)/add.tsx
@@ -1,6 +1,7 @@
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 
 export default function AddScreen() {
@@ -12,7 +13,7 @@ export default function AddScreen() {
         <Text style={styles.title}>{t('add.title')}</Text>
       </View>
       <View style={styles.options}>
-        <TouchableOpacity style={styles.option}>
+        <TouchableOpacity style={styles.option} onPress={() => router.push('/add/scan-barcode')}>
           <View style={[styles.iconBox, { backgroundColor: '#FFF3E0' }]}>
             <Ionicons name="barcode-outline" size={26} color="#FF8400" />
           </View>

--- a/app/add/_layout.tsx
+++ b/app/add/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function AddLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="scan-barcode" />
+      <Stack.Screen name="product-confirm" />
+    </Stack>
+  );
+}

--- a/app/add/product-confirm.tsx
+++ b/app/add/product-confirm.tsx
@@ -1,0 +1,331 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '@/lib/supabase';
+import { addToStock } from '@/features/stock/services/stockService';
+import type { Lieu, ScannedProduct, StockItemDraft, Unite } from '@/features/scanning/types';
+
+const LIEUX: { value: Lieu; label: string; icon: string }[] = [
+  { value: 'frigo', label: 'productConfirm.frigo', icon: 'snow-outline' },
+  { value: 'placard', label: 'productConfirm.placard', icon: 'cube-outline' },
+  { value: 'congelateur', label: 'productConfirm.congelateur', icon: 'thermometer-outline' },
+];
+
+const UNITES: Unite[] = ['pièce', 'g', 'kg', 'ml', 'L', 'boîte', 'sachet'];
+
+export default function ProductConfirmScreen() {
+  const { t } = useTranslation();
+  const params = useLocalSearchParams<{ product: string; notFound?: string }>();
+  const notFound = params.notFound === '1';
+
+  const initial: ScannedProduct = JSON.parse(params.product);
+
+  const [nom, setNom] = useState(initial.nom);
+  const [quantite, setQuantite] = useState('1');
+  const [unite, setUnite] = useState<Unite>('pièce');
+  const [lieu, setLieu] = useState<Lieu>('frigo');
+  const [datePeremption, setDatePeremption] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    if (!nom.trim()) {
+      Alert.alert(t('productConfirm.errorNomRequired'));
+      return;
+    }
+
+    const qty = parseFloat(quantite.replace(',', '.'));
+    if (isNaN(qty) || qty <= 0) {
+      Alert.alert(t('productConfirm.errorQuantite'));
+      return;
+    }
+
+    // Validate date if provided (YYYY-MM-DD)
+    let isoDate: string | null = null;
+    if (datePeremption.trim()) {
+      const parts = datePeremption.trim().split('/');
+      if (parts.length === 3) {
+        const [day, month, year] = parts;
+        isoDate = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+      } else {
+        Alert.alert(t('productConfirm.errorDateFormat'));
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        Alert.alert(t('productConfirm.errorNotLoggedIn'));
+        return;
+      }
+
+      // Get user's foyer
+      const { data: membre } = await supabase
+        .from('foyer_membres')
+        .select('foyer_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+
+      if (!membre) {
+        Alert.alert(t('productConfirm.errorNoFoyer'));
+        return;
+      }
+
+      const draft: StockItemDraft = {
+        scannedProduct: { ...initial, nom: nom.trim() },
+        quantite: qty,
+        unite,
+        datePeremption: isoDate,
+        lieu,
+      };
+
+      await addToStock(draft, membre.foyer_id as string, session.user.id);
+
+      router.replace('/(tabs)/stock');
+    } catch {
+      Alert.alert(t('common.error'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* Header */}
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+            <Ionicons name="arrow-back" size={24} color="#111111" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>{t('productConfirm.title')}</Text>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          {/* Not found banner */}
+          {notFound && (
+            <View style={styles.banner}>
+              <Ionicons name="information-circle-outline" size={18} color="#1565C0" />
+              <Text style={styles.bannerText}>{t('productConfirm.notFound')}</Text>
+            </View>
+          )}
+
+          {/* Product image */}
+          {initial.imageUrl ? (
+            <Image source={{ uri: initial.imageUrl }} style={styles.productImage} resizeMode="contain" />
+          ) : (
+            <View style={styles.productImagePlaceholder}>
+              <Ionicons name="image-outline" size={40} color="#D1D5DB" />
+            </View>
+          )}
+
+          {/* Nom */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('productConfirm.nom')}</Text>
+            <TextInput
+              style={styles.input}
+              value={nom}
+              onChangeText={setNom}
+              placeholder={t('productConfirm.nomPlaceholder')}
+              placeholderTextColor="#9CA3AF"
+            />
+          </View>
+
+          {/* Marque (readonly) */}
+          {initial.marque ? (
+            <View style={styles.field}>
+              <Text style={styles.label}>{t('productConfirm.marque')}</Text>
+              <Text style={styles.readonlyValue}>{initial.marque}</Text>
+            </View>
+          ) : null}
+
+          {/* Quantité + Unité */}
+          <View style={styles.row}>
+            <View style={[styles.field, styles.flex]}>
+              <Text style={styles.label}>{t('productConfirm.quantite')}</Text>
+              <TextInput
+                style={styles.input}
+                value={quantite}
+                onChangeText={setQuantite}
+                keyboardType="decimal-pad"
+                placeholder="1"
+                placeholderTextColor="#9CA3AF"
+              />
+            </View>
+            <View style={[styles.field, { width: 110 }]}>
+              <Text style={styles.label}>{t('productConfirm.unite')}</Text>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <View style={styles.uniteRow}>
+                  {UNITES.map((u) => (
+                    <TouchableOpacity
+                      key={u}
+                      style={[styles.uniteChip, unite === u && styles.uniteChipActive]}
+                      onPress={() => setUnite(u)}
+                    >
+                      <Text style={[styles.uniteChipText, unite === u && styles.uniteChipTextActive]}>
+                        {u}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </ScrollView>
+            </View>
+          </View>
+
+          {/* Date de péremption */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('productConfirm.datePeremption')}</Text>
+            <TextInput
+              style={styles.input}
+              value={datePeremption}
+              onChangeText={setDatePeremption}
+              placeholder="JJ/MM/AAAA"
+              placeholderTextColor="#9CA3AF"
+              keyboardType="numeric"
+            />
+          </View>
+
+          {/* Lieu */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('productConfirm.lieu')}</Text>
+            <View style={styles.lieuRow}>
+              {LIEUX.map((l) => (
+                <TouchableOpacity
+                  key={l.value}
+                  style={[styles.lieuBtn, lieu === l.value && styles.lieuBtnActive]}
+                  onPress={() => setLieu(l.value)}
+                >
+                  <Ionicons
+                    name={l.icon as any}
+                    size={20}
+                    color={lieu === l.value ? '#FF8400' : '#6B7280'}
+                  />
+                  <Text style={[styles.lieuBtnText, lieu === l.value && styles.lieuBtnTextActive]}>
+                    {t(l.label)}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Save button */}
+          <TouchableOpacity
+            style={[styles.saveBtn, saving && styles.saveBtnDisabled]}
+            onPress={handleSave}
+            disabled={saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.saveBtnText}>{t('productConfirm.addToStock')}</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: '#F2F3F0' },
+  flex: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#F2F3F0',
+  },
+  backBtn: { padding: 4 },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#111111' },
+  content: { paddingHorizontal: 20, paddingBottom: 40, gap: 16 },
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#E3F2FD',
+    borderRadius: 10,
+    padding: 12,
+  },
+  bannerText: { flex: 1, fontSize: 13, color: '#1565C0' },
+  productImage: {
+    width: '100%',
+    height: 160,
+    borderRadius: 14,
+    backgroundColor: '#FFFFFF',
+  },
+  productImagePlaceholder: {
+    width: '100%',
+    height: 120,
+    borderRadius: 14,
+    backgroundColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  field: { gap: 6 },
+  label: { fontSize: 13, fontWeight: '600', color: '#374151', textTransform: 'uppercase', letterSpacing: 0.5 },
+  input: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '#111111',
+  },
+  readonlyValue: { fontSize: 15, color: '#6B7280', paddingHorizontal: 14, paddingVertical: 4 },
+  row: { flexDirection: 'row', gap: 12 },
+  uniteRow: { flexDirection: 'row', gap: 6 },
+  uniteChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  uniteChipActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
+  uniteChipText: { fontSize: 13, color: '#6B7280' },
+  uniteChipTextActive: { color: '#FF8400', fontWeight: '600' },
+  lieuRow: { flexDirection: 'row', gap: 10 },
+  lieuBtn: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
+  lieuBtnText: { fontSize: 12, color: '#6B7280', textAlign: 'center' },
+  lieuBtnTextActive: { color: '#FF8400', fontWeight: '600' },
+  saveBtn: {
+    backgroundColor: '#FF8400',
+    borderRadius: 14,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  saveBtnDisabled: { opacity: 0.6 },
+  saveBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+});

--- a/app/add/scan-barcode.tsx
+++ b/app/add/scan-barcode.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { router } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTranslation } from 'react-i18next';
+import { fetchProductByEan } from '@/features/scanning/services/openFoodFactsService';
+import type { ScannedProduct } from '@/features/scanning/types';
+
+export default function ScanBarcodeScreen() {
+  const { t } = useTranslation();
+  const [permission, requestPermission] = useCameraPermissions();
+  const [scanning, setScanning] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const lastScanned = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!permission?.granted) {
+      requestPermission();
+    }
+  }, [permission, requestPermission]);
+
+  async function handleBarCodeScanned({ data: ean }: { data: string }) {
+    if (!scanning || loading || lastScanned.current === ean) return;
+    lastScanned.current = ean;
+    setScanning(false);
+    setLoading(true);
+    setError(null);
+
+    try {
+      const product = await fetchProductByEan(ean);
+
+      if (product) {
+        router.replace({
+          pathname: '/add/product-confirm',
+          params: { product: JSON.stringify(product) },
+        });
+      } else {
+        // Product not in OFF → go to manual form pre-filled with EAN
+        const fallback: ScannedProduct = { ean, nom: '' };
+        router.replace({
+          pathname: '/add/product-confirm',
+          params: { product: JSON.stringify(fallback), notFound: '1' },
+        });
+      }
+    } catch {
+      setError(t('scan.errorNetwork'));
+      setLoading(false);
+      setScanning(true);
+      lastScanned.current = null;
+    }
+  }
+
+  if (!permission) {
+    return (
+      <SafeAreaView style={styles.centered}>
+        <ActivityIndicator color="#FF8400" />
+      </SafeAreaView>
+    );
+  }
+
+  if (!permission.granted) {
+    return (
+      <SafeAreaView style={styles.centered}>
+        <Ionicons name="camera-outline" size={48} color="#9CA3AF" />
+        <Text style={styles.permissionText}>{t('scan.cameraPermission')}</Text>
+        <TouchableOpacity style={styles.permissionBtn} onPress={requestPermission}>
+          <Text style={styles.permissionBtnText}>{t('scan.grantPermission')}</Text>
+        </TouchableOpacity>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <CameraView
+        style={StyleSheet.absoluteFill}
+        facing="back"
+        onBarcodeScanned={scanning ? handleBarCodeScanned : undefined}
+        barcodeScannerSettings={{ barcodeTypes: ['ean13', 'ean8', 'upc_a', 'upc_e'] }}
+      />
+
+      {/* Header overlay */}
+      <SafeAreaView style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+          <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>{t('scan.title')}</Text>
+      </SafeAreaView>
+
+      {/* Viewfinder */}
+      <View style={styles.viewfinderContainer}>
+        <View style={styles.viewfinder}>
+          <View style={[styles.corner, styles.topLeft]} />
+          <View style={[styles.corner, styles.topRight]} />
+          <View style={[styles.corner, styles.bottomLeft]} />
+          <View style={[styles.corner, styles.bottomRight]} />
+        </View>
+        <Text style={styles.hint}>{t('scan.hint')}</Text>
+      </View>
+
+      {/* Loading overlay */}
+      {loading && (
+        <View style={styles.loadingOverlay}>
+          <ActivityIndicator size="large" color="#FF8400" />
+          <Text style={styles.loadingText}>{t('scan.searching')}</Text>
+        </View>
+      )}
+
+      {/* Error toast */}
+      {error && (
+        <View style={styles.errorToast}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const CORNER = 24;
+const BORDER = 3;
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16, backgroundColor: '#F2F3F0' },
+  permissionText: { fontSize: 15, color: '#6B7280', textAlign: 'center', paddingHorizontal: 40 },
+  permissionBtn: { backgroundColor: '#FF8400', paddingHorizontal: 24, paddingVertical: 12, borderRadius: 12 },
+  permissionBtnText: { color: '#FFFFFF', fontWeight: '600', fontSize: 15 },
+
+  header: {
+    position: 'absolute',
+    top: 0, left: 0, right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  backBtn: { padding: 4 },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#FFFFFF' },
+
+  viewfinderContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 24,
+  },
+  viewfinder: {
+    width: 260,
+    height: 160,
+    position: 'relative',
+  },
+  corner: {
+    position: 'absolute',
+    width: CORNER,
+    height: CORNER,
+    borderColor: '#FF8400',
+  },
+  topLeft: { top: 0, left: 0, borderTopWidth: BORDER, borderLeftWidth: BORDER, borderTopLeftRadius: 4 },
+  topRight: { top: 0, right: 0, borderTopWidth: BORDER, borderRightWidth: BORDER, borderTopRightRadius: 4 },
+  bottomLeft: { bottom: 0, left: 0, borderBottomWidth: BORDER, borderLeftWidth: BORDER, borderBottomLeftRadius: 4 },
+  bottomRight: { bottom: 0, right: 0, borderBottomWidth: BORDER, borderRightWidth: BORDER, borderBottomRightRadius: 4 },
+  hint: { color: '#FFFFFF', fontSize: 14, textAlign: 'center' },
+
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+  },
+  loadingText: { color: '#FFFFFF', fontSize: 15 },
+
+  errorToast: {
+    position: 'absolute',
+    bottom: 48,
+    left: 24,
+    right: 24,
+    backgroundColor: '#B91C1C',
+    borderRadius: 12,
+    padding: 14,
+    alignItems: 'center',
+  },
+  errorText: { color: '#FFFFFF', fontSize: 14, fontWeight: '500' },
+});

--- a/features/scanning/services/openFoodFactsService.ts
+++ b/features/scanning/services/openFoodFactsService.ts
@@ -1,0 +1,77 @@
+import type { OFFProduct, ScannedProduct } from '../types';
+
+const OFF_API_BASE = 'https://world.openfoodfacts.org/api/v0/product';
+
+// Maps OFF category tags to normalized ingredient tags
+const CATEGORY_TO_TAG: Record<string, string> = {
+  'en:milks': 'lait',
+  'en:yogurts': 'yaourt',
+  'en:cheeses': 'fromage',
+  'en:butters': 'beurre',
+  'en:eggs': 'oeuf',
+  'en:breads': 'pain',
+  'en:pastas': 'pates',
+  'en:rices': 'riz',
+  'en:flours': 'farine',
+  'en:sugars': 'sucre',
+  'en:salts': 'sel',
+  'en:olive-oils': 'huile-olive',
+  'en:vegetable-oils': 'huile',
+  'en:tomatoes': 'tomate',
+  'en:carrots': 'carotte',
+  'en:onions': 'oignon',
+  'en:potatoes': 'pomme-de-terre',
+  'en:chickens': 'poulet',
+  'en:beefs': 'boeuf',
+  'en:porks': 'porc',
+  'en:salmons': 'saumon',
+  'en:tunas': 'thon',
+  'en:chocolates': 'chocolat',
+  'en:coffees': 'cafe',
+  'en:teas': 'the',
+  'en:juices': 'jus',
+  'en:waters': 'eau',
+  'en:beers': 'biere',
+  'en:wines': 'vin',
+};
+
+function extractIngredientTag(categoriesTags?: string[]): string | undefined {
+  if (!categoriesTags) return undefined;
+  for (const tag of categoriesTags) {
+    if (CATEGORY_TO_TAG[tag]) return CATEGORY_TO_TAG[tag];
+  }
+  return undefined;
+}
+
+function extractNom(product: OFFProduct['product']): string {
+  return (
+    product.product_name_fr ||
+    product.product_name ||
+    'Produit inconnu'
+  ).trim();
+}
+
+export async function fetchProductByEan(ean: string): Promise<ScannedProduct | null> {
+  const response = await fetch(`${OFF_API_BASE}/${ean}.json`);
+
+  if (!response.ok) {
+    throw new Error(`OFF API error: ${response.status}`);
+  }
+
+  const data: OFFProduct = await response.json();
+
+  if (data.status === 0) {
+    return null; // Product not found in OFF
+  }
+
+  const { product } = data;
+
+  return {
+    ean,
+    nom: extractNom(product),
+    marque: product.brands?.split(',')[0].trim(),
+    categorie: product.categories?.split(',')[0].trim(),
+    ingredientTag: extractIngredientTag(product.categories_tags),
+    imageUrl: product.image_front_url || product.image_url,
+  };
+}

--- a/features/scanning/types.ts
+++ b/features/scanning/types.ts
@@ -1,12 +1,24 @@
-export interface OpenFoodFactsProduct {
+export interface OFFProduct {
   code: string;
+  status: number; // 1 = found, 0 = not found
   product: {
     product_name: string;
+    product_name_fr?: string;
     brands?: string;
     categories?: string;
+    categories_tags?: string[];
     image_url?: string;
+    image_front_url?: string;
   };
-  status: number;
+}
+
+export interface ScannedProduct {
+  ean: string;
+  nom: string;
+  marque?: string;
+  categorie?: string;
+  ingredientTag?: string;
+  imageUrl?: string;
 }
 
 export interface ReceiptProduct {
@@ -15,4 +27,15 @@ export interface ReceiptProduct {
   quantiteEstimee?: number;
   unite?: string;
   dureeConservationJours?: number;
+}
+
+export type Lieu = 'frigo' | 'congelateur' | 'placard';
+export type Unite = 'pièce' | 'g' | 'kg' | 'ml' | 'L' | 'boîte' | 'sachet';
+
+export interface StockItemDraft {
+  scannedProduct: ScannedProduct;
+  quantite: number;
+  unite: Unite;
+  datePeremption: string | null; // ISO date YYYY-MM-DD
+  lieu: Lieu;
 }

--- a/features/stock/services/stockService.ts
+++ b/features/stock/services/stockService.ts
@@ -1,0 +1,55 @@
+import { supabase } from '@/lib/supabase';
+import type { ScannedProduct, StockItemDraft } from '@/features/scanning/types';
+
+async function upsertProduit(scannedProduct: ScannedProduct): Promise<string> {
+  const { ean, nom, marque, categorie, imageUrl } = scannedProduct;
+
+  // Try to find existing produit by EAN
+  if (ean) {
+    const { data: existing } = await supabase
+      .from('produits')
+      .select('id')
+      .eq('ean', ean)
+      .maybeSingle();
+
+    if (existing) return existing.id as string;
+  }
+
+  // Insert new produit
+  const { data, error } = await supabase
+    .from('produits')
+    .insert({
+      ean: ean || null,
+      nom,
+      marque: marque || null,
+      categorie: categorie || null,
+      image_url: imageUrl || null,
+      source: ean ? 'open_food_facts' : 'manuel',
+    })
+    .select('id')
+    .single();
+
+  if (error) throw error;
+  return data.id as string;
+}
+
+export async function addToStock(
+  draft: StockItemDraft,
+  foyerId: string,
+  addedBy: string,
+): Promise<void> {
+  const produitId = await upsertProduit(draft.scannedProduct);
+
+  const { error } = await supabase.from('stock_items').insert({
+    foyer_id: foyerId,
+    added_by: addedBy,
+    produit_id: produitId,
+    ingredient_tag: draft.scannedProduct.ingredientTag || null,
+    quantite: draft.quantite,
+    unite: draft.unite,
+    date_peremption: draft.datePeremption || null,
+    lieu: draft.lieu,
+  });
+
+  if (error) throw error;
+}

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -37,6 +37,34 @@
     "scanReceipt": "Scanner un ticket de caisse",
     "manual": "Ajouter manuellement"
   },
+  "scan": {
+    "title": "Scanner un code-barres",
+    "hint": "Pointez la caméra vers le code-barres",
+    "searching": "Recherche du produit…",
+    "errorNetwork": "Impossible de récupérer le produit. Vérifiez votre connexion.",
+    "cameraPermission": "L'accès à la caméra est nécessaire pour scanner un code-barres.",
+    "grantPermission": "Autoriser la caméra"
+  },
+  "productConfirm": {
+    "title": "Confirmer le produit",
+    "notFound": "Produit introuvable dans Open Food Facts. Renseignez les informations manuellement.",
+    "nom": "Nom du produit",
+    "nomPlaceholder": "Ex : Lait demi-écrémé",
+    "marque": "Marque",
+    "quantite": "Quantité",
+    "unite": "Unité",
+    "datePeremption": "Date de péremption (optionnel)",
+    "lieu": "Rangement",
+    "frigo": "Frigo",
+    "placard": "Placard",
+    "congelateur": "Congélateur",
+    "addToStock": "Ajouter au stock",
+    "errorNomRequired": "Le nom du produit est obligatoire.",
+    "errorQuantite": "La quantité doit être un nombre positif.",
+    "errorDateFormat": "Format de date invalide. Utilisez JJ/MM/AAAA.",
+    "errorNotLoggedIn": "Vous devez être connecté pour ajouter un produit.",
+    "errorNoFoyer": "Aucun foyer associé à votre compte."
+  },
   "recipes": {
     "title": "Recettes",
     "emptyState": "Aucune recette trouvée",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@supabase/supabase-js": "^2.97.0",
         "expo": "~54.0.33",
+        "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
         "expo-linking": "~8.0.11",
         "expo-localization": "~17.0.8",
@@ -7793,6 +7794,26 @@
           "optional": true
         },
         "react-native-webview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.10.tgz",
+      "integrity": "sha512-w1RBw83mAGVk4BPPwNrCZyFop0VLiVSRE3c2V9onWbdFwonpRhzmB4drygG8YOUTl1H3wQvALJHyMPTbgsK1Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@supabase/supabase-js": "^2.97.0",
     "expo": "~54.0.33",
+    "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",


### PR DESCRIPTION
## Summary

- **`app/add/scan-barcode.tsx`** — écran caméra avec `CameraView` (expo-camera), viewfinder orange, gestion permission, overlay loading/erreur
- **`app/add/product-confirm.tsx`** — formulaire de confirmation : nom, quantité, unité, date de péremption (JJ/MM/AAAA), lieu (frigo/placard/congélateur)
- **`features/scanning/services/openFoodFactsService.ts`** — appel OFF API, mapping catégories → `ingredient_tag`, fallback si produit inconnu
- **`features/stock/services/stockService.ts`** — upsert `produits` (évite les doublons par EAN) puis insert `stock_items`
- Fallback saisie manuelle si produit non trouvé dans OFF
- Clés i18n ajoutées : `scan.*`, `productConfirm.*`
- Permission caméra déclarée dans `app.json`

## Test plan

- [ ] Scanner un EAN connu (ex: 3017620422003 — Nutella) → produit pré-rempli
- [ ] Scanner un EAN inconnu → bannière "produit introuvable", champ nom vide à remplir
- [ ] Refuser la permission caméra → écran de demande de permission
- [ ] Valider avec date péremption invalide → alerte format
- [ ] Valider sans nom → alerte obligatoire
- [ ] Valider → insert dans Supabase, redirect vers stock

🤖 Generated with [Claude Code](https://claude.com/claude-code)