### PR TITLE
feat(auth): Sign in with Apple natif (#7)

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,6 +35,7 @@
       "expo-dev-client",
       "expo-localization",
       "expo-router",
+      "expo-apple-authentication",
       [
         "expo-camera",
         {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -13,14 +13,16 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
+import * as AppleAuthentication from 'expo-apple-authentication';
 import { useTranslation } from 'react-i18next';
-import { signIn } from '@/features/auth/services/authService';
+import { signIn, signInWithApple } from '@/features/auth/services/authService';
 
 export default function LoginScreen() {
   const { t } = useTranslation();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [appleLoading, setAppleLoading] = useState(false);
 
   async function handleLogin() {
     if (!email.trim() || !password) {
@@ -33,10 +35,24 @@ export default function LoginScreen() {
       await signIn(email.trim().toLowerCase(), password);
       // useAuth in _layout.tsx will redirect to tabs
     } catch (err: any) {
-      const message = mapAuthError(err?.message);
-      Alert.alert(t('auth.errorTitle'), t(message));
+      Alert.alert(t('auth.errorTitle'), t(mapAuthError(err?.message)));
     } finally {
       setLoading(false);
+    }
+  }
+
+  async function handleAppleSignIn() {
+    setAppleLoading(true);
+    try {
+      await signInWithApple();
+      // useAuth in _layout.tsx will redirect to tabs
+    } catch (err: any) {
+      // ERR_CANCELED = user dismissed the sheet — not an error
+      if (err?.code !== 'ERR_REQUEST_CANCELED') {
+        Alert.alert(t('auth.errorTitle'), t('auth.errorGeneric'));
+      }
+    } finally {
+      setAppleLoading(false);
     }
   }
 
@@ -56,7 +72,28 @@ export default function LoginScreen() {
             <Text style={styles.tagline}>{t('auth.tagline')}</Text>
           </View>
 
-          {/* Form */}
+          {/* Apple Sign In — iOS only */}
+          {Platform.OS === 'ios' && (
+            <View style={styles.socialSection}>
+              <AppleAuthentication.AppleAuthenticationButton
+                buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+                buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+                cornerRadius={14}
+                style={styles.appleBtn}
+                onPress={handleAppleSignIn}
+              />
+              {appleLoading && (
+                <ActivityIndicator style={styles.appleLoader} color="#111111" />
+              )}
+              <View style={styles.dividerRow}>
+                <View style={styles.dividerLine} />
+                <Text style={styles.dividerText}>{t('auth.orEmail')}</Text>
+                <View style={styles.dividerLine} />
+              </View>
+            </View>
+          )}
+
+          {/* Email / Password form */}
           <View style={styles.form}>
             <View style={styles.field}>
               <Text style={styles.label}>{t('auth.email')}</Text>
@@ -130,10 +167,16 @@ function mapAuthError(message?: string): string {
 const styles = StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: '#F2F3F0' },
   flex: { flex: 1 },
-  content: { flexGrow: 1, paddingHorizontal: 24, paddingTop: 48, paddingBottom: 32, gap: 32 },
+  content: { flexGrow: 1, paddingHorizontal: 24, paddingTop: 48, paddingBottom: 32, gap: 28 },
   logoContainer: { alignItems: 'center', gap: 8 },
   logo: { fontSize: 48, fontWeight: '800', color: '#FF8400', letterSpacing: -1 },
   tagline: { fontSize: 15, color: '#6B7280', textAlign: 'center' },
+  socialSection: { gap: 16 },
+  appleBtn: { width: '100%', height: 52 },
+  appleLoader: { position: 'absolute', alignSelf: 'center' },
+  dividerRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  dividerLine: { flex: 1, height: 1, backgroundColor: '#E5E7EB' },
+  dividerText: { fontSize: 13, color: '#9CA3AF' },
   form: { gap: 16 },
   field: { gap: 6 },
   label: { fontSize: 13, fontWeight: '600', color: '#374151', textTransform: 'uppercase', letterSpacing: 0.5 },

--- a/features/auth/services/authService.ts
+++ b/features/auth/services/authService.ts
@@ -1,3 +1,4 @@
+import * as AppleAuthentication from 'expo-apple-authentication';
 import { supabase } from '@/lib/supabase';
 
 export async function signIn(email: string, password: string) {
@@ -20,4 +21,25 @@ export async function signOut() {
 export async function resetPassword(email: string) {
   const { error } = await supabase.auth.resetPasswordForEmail(email);
   if (error) throw error;
+}
+
+export async function signInWithApple() {
+  const credential = await AppleAuthentication.signInAsync({
+    requestedScopes: [
+      AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+      AppleAuthentication.AppleAuthenticationScope.EMAIL,
+    ],
+  });
+
+  if (!credential.identityToken) {
+    throw new Error('Apple Sign In did not return an identity token');
+  }
+
+  const { data, error } = await supabase.auth.signInWithIdToken({
+    provider: 'apple',
+    token: credential.identityToken,
+  });
+
+  if (error) throw error;
+  return data.session;
 }

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -93,7 +93,8 @@
     "errorPasswordTooShort": "Le mot de passe doit contenir au moins 8 caractères.",
     "errorPasswordMismatch": "Les mots de passe ne correspondent pas.",
     "errorRateLimit": "Trop de tentatives. Veuillez réessayer dans quelques minutes.",
-    "errorGeneric": "Une erreur est survenue. Veuillez réessayer."
+    "errorGeneric": "Une erreur est survenue. Veuillez réessayer.",
+    "orEmail": "ou avec votre email"
   },
   "recipes": {
     "title": "Recettes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@supabase/supabase-js": "^2.97.0",
         "expo": "~54.0.33",
+        "expo-apple-authentication": "~8.0.8",
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
@@ -7797,6 +7798,16 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-apple-authentication": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-apple-authentication/-/expo-apple-authentication-8.0.8.tgz",
+      "integrity": "sha512-TwCHWXYR1kS0zaeV7QZKLWYluxsvqL31LFJubzK30njZqeWoWO89HZ8nZVaeXbFV1LrArKsze4BmMb+94wS0AQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-camera": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@supabase/supabase-js": "^2.97.0",
     "expo": "~54.0.33",
+    "expo-apple-authentication": "~8.0.8",
     "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",


### PR DESCRIPTION
## Summary

- **`signInWithApple()`** dans `authService` : déclenche la sheet native Apple → récupère l'`identityToken` → `supabase.auth.signInWithIdToken({ provider: 'apple', token })`
- **Bouton officiel Apple** (`AppleAuthenticationButton`) dans `login.tsx` — iOS uniquement via `Platform.OS === 'ios'`, conforme aux guidelines Apple (style BLACK, cornerRadius 14)
- Annulation de la sheet (`ERR_REQUEST_CANCELED`) silencieuse — pas d'alerte d'erreur
- Plugin `expo-apple-authentication` ajouté dans `app.json` (active la capability Xcode automatiquement au build EAS)

## Configuration App Store Connect requise (manuelle)

1. Sur [developer.apple.com](https://developer.apple.com) → Certificates, IDs & Profiles → activer **Sign in with Apple** sur l'App ID `com.loicmonard.fridgy`
2. Sur Supabase dashboard → Auth → Providers → **Apple** → activer + renseigner `Services ID` et la clé privée

## Test plan

- [ ] Sur iOS : bouton Apple visible au-dessus du formulaire email
- [ ] Sur Android : bouton Apple absent
- [ ] Tap bouton → sheet Apple native s'ouvre
- [ ] Annulation → aucune alerte, retour à l'écran
- [ ] Connexion Apple réussie → session Supabase créée → redirect vers tabs
- [ ] Rouvrir l'app → session Apple persistée

🤖 Generated with [Claude Code](https://claude.com/claude-code)