### PR TITLE
feat(auth): Google Sign In natif (#6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,11 @@
 EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 
+# Google Sign In
+# iOS Client ID : Google Cloud Console → OAuth → Client ID type "iOS"
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=your-ios-client-id.apps.googleusercontent.com
+# Web Client ID : Google Cloud Console → OAuth → Client ID type "Web application"
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
+
 # Gemini — côté Vercel Edge Function uniquement, jamais dans l'app
 # GEMINI_API_KEY=your-gemini-key

--- a/app.json
+++ b/app.json
@@ -42,6 +42,12 @@
           "cameraPermission": "Fridgy a besoin de la caméra pour scanner les codes-barres.",
           "microphonePermission": false
         }
+      ],
+      [
+        "@react-native-google-signin/google-signin",
+        {
+          "iosUrlScheme": "com.googleusercontent.apps.$(GOOGLE_IOS_CLIENT_ID_REVERSED)"
+        }
       ]
     ]
   }

--- a/app.json
+++ b/app.json
@@ -15,7 +15,10 @@
     "scheme": "fridgy",
     "ios": {
       "supportsTablet": false,
-      "bundleIdentifier": "com.loicmonard.fridgy"
+      "bundleIdentifier": "com.loicmonard.fridgy",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.loicmonard.fridgy",
@@ -24,7 +27,11 @@
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "permissions": [
+        "android.permission.CAMERA",
+        "android.permission.RECORD_AUDIO"
+      ]
     },
     "web": {
       "bundler": "metro",
@@ -46,9 +53,15 @@
       [
         "@react-native-google-signin/google-signin",
         {
-          "iosUrlScheme": "com.googleusercontent.apps.$(GOOGLE_IOS_CLIENT_ID_REVERSED)"
+          "iosUrlScheme": "com.googleusercontent.apps.1068503426751-pl3cib3g60llhit4ltahiaeb5t57v5ca"
         }
       ]
-    ]
+    ],
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "195f312a-3f06-4938-8420-28a455a7637d"
+      }
+    }
   }
 }

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Image,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -15,7 +16,15 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import * as AppleAuthentication from 'expo-apple-authentication';
 import { useTranslation } from 'react-i18next';
-import { signIn, signInWithApple } from '@/features/auth/services/authService';
+import {
+  configureGoogleSignIn,
+  signIn,
+  signInWithApple,
+  signInWithGoogle,
+} from '@/features/auth/services/authService';
+
+const IOS_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID ?? '';
+const WEB_CLIENT_ID = process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID ?? '';
 
 export default function LoginScreen() {
   const { t } = useTranslation();
@@ -23,17 +32,20 @@ export default function LoginScreen() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [appleLoading, setAppleLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
+
+  useEffect(() => {
+    configureGoogleSignIn(IOS_CLIENT_ID, WEB_CLIENT_ID);
+  }, []);
 
   async function handleLogin() {
     if (!email.trim() || !password) {
       Alert.alert(t('auth.errorFieldsRequired'));
       return;
     }
-
     setLoading(true);
     try {
       await signIn(email.trim().toLowerCase(), password);
-      // useAuth in _layout.tsx will redirect to tabs
     } catch (err: any) {
       Alert.alert(t('auth.errorTitle'), t(mapAuthError(err?.message)));
     } finally {
@@ -41,20 +53,35 @@ export default function LoginScreen() {
     }
   }
 
+  async function handleGoogleSignIn() {
+    setGoogleLoading(true);
+    try {
+      await signInWithGoogle();
+    } catch (err: any) {
+      if (err?.code !== 'SIGN_IN_CANCELLED') {
+        console.error('[Google Sign In]', err?.code, err?.message);
+        Alert.alert(t('auth.errorTitle'), t('auth.errorGeneric'));
+      }
+    } finally {
+      setGoogleLoading(false);
+    }
+  }
+
   async function handleAppleSignIn() {
     setAppleLoading(true);
     try {
       await signInWithApple();
-      // useAuth in _layout.tsx will redirect to tabs
     } catch (err: any) {
-      // ERR_CANCELED = user dismissed the sheet — not an error
       if (err?.code !== 'ERR_REQUEST_CANCELED') {
+        console.error('[Apple Sign In] code:', err?.code, '| message:', err?.message);
         Alert.alert(t('auth.errorTitle'), t('auth.errorGeneric'));
       }
     } finally {
       setAppleLoading(false);
     }
   }
+
+  const showSocialSection = Platform.OS === 'ios' || Platform.OS === 'android';
 
   return (
     <SafeAreaView style={styles.safeArea}>
@@ -72,19 +99,39 @@ export default function LoginScreen() {
             <Text style={styles.tagline}>{t('auth.tagline')}</Text>
           </View>
 
-          {/* Apple Sign In — iOS only */}
-          {Platform.OS === 'ios' && (
+          {/* Social buttons */}
+          {showSocialSection && (
             <View style={styles.socialSection}>
-              <AppleAuthentication.AppleAuthenticationButton
-                buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
-                buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
-                cornerRadius={14}
-                style={styles.appleBtn}
-                onPress={handleAppleSignIn}
-              />
-              {appleLoading && (
-                <ActivityIndicator style={styles.appleLoader} color="#111111" />
+              {/* Google — iOS + Android */}
+              <TouchableOpacity
+                style={[styles.googleBtn, googleLoading && styles.btnDisabled]}
+                onPress={handleGoogleSignIn}
+                disabled={googleLoading}
+              >
+                {googleLoading ? (
+                  <ActivityIndicator color="#374151" />
+                ) : (
+                  <>
+                    <Image
+                      source={{ uri: 'https://www.gstatic.com/firebasejs/ui/2.0.0/images/auth/google.svg' }}
+                      style={styles.googleIcon}
+                    />
+                    <Text style={styles.googleBtnText}>{t('auth.continueWithGoogle')}</Text>
+                  </>
+                )}
+              </TouchableOpacity>
+
+              {/* Apple — iOS only */}
+              {Platform.OS === 'ios' && (
+                <AppleAuthentication.AppleAuthenticationButton
+                  buttonType={AppleAuthentication.AppleAuthenticationButtonType.SIGN_IN}
+                  buttonStyle={AppleAuthentication.AppleAuthenticationButtonStyle.BLACK}
+                  cornerRadius={14}
+                  style={styles.appleBtn}
+                  onPress={handleAppleSignIn}
+                />
               )}
+
               <View style={styles.dividerRow}>
                 <View style={styles.dividerLine} />
                 <Text style={styles.dividerText}>{t('auth.orEmail')}</Text>
@@ -171,9 +218,21 @@ const styles = StyleSheet.create({
   logoContainer: { alignItems: 'center', gap: 8 },
   logo: { fontSize: 48, fontWeight: '800', color: '#FF8400', letterSpacing: -1 },
   tagline: { fontSize: 15, color: '#6B7280', textAlign: 'center' },
-  socialSection: { gap: 16 },
+  socialSection: { gap: 12 },
+  googleBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    paddingVertical: 14,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  googleIcon: { width: 20, height: 20 },
+  googleBtnText: { fontSize: 15, fontWeight: '600', color: '#374151' },
   appleBtn: { width: '100%', height: 52 },
-  appleLoader: { position: 'absolute', alignSelf: 'center' },
   dividerRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
   dividerLine: { flex: 1, height: 1, backgroundColor: '#E5E7EB' },
   dividerText: { fontSize: 13, color: '#9CA3AF' },

--- a/eas.json
+++ b/eas.json
@@ -10,10 +10,8 @@
       "ios": {
         "simulator": false
       },
-      "env": {
-        "EXPO_PUBLIC_SUPABASE_URL": "",
-        "EXPO_PUBLIC_SUPABASE_ANON_KEY": ""
-      }
+      "env": {}
+
     },
     "preview": {
       "distribution": "internal",
@@ -25,16 +23,6 @@
     }
   },
   "submit": {
-    "production": {
-      "ios": {
-        "appleId": "loicmonard@example.com",
-        "ascAppId": "",
-        "appleTeamId": ""
-      },
-      "android": {
-        "serviceAccountKeyPath": "./google-services-key.json",
-        "track": "internal"
-      }
-    }
+    "production": {}
   }
 }

--- a/features/auth/services/authService.ts
+++ b/features/auth/services/authService.ts
@@ -1,4 +1,5 @@
 import * as AppleAuthentication from 'expo-apple-authentication';
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
 import { supabase } from '@/lib/supabase';
 
 export async function signIn(email: string, password: string) {
@@ -23,6 +24,27 @@ export async function resetPassword(email: string) {
   if (error) throw error;
 }
 
+export function configureGoogleSignIn(iosClientId: string, webClientId: string) {
+  GoogleSignin.configure({ iosClientId, webClientId });
+}
+
+export async function signInWithGoogle() {
+  await GoogleSignin.hasPlayServices();
+  const { data } = await GoogleSignin.signIn();
+
+  if (!data?.idToken) {
+    throw new Error('Google Sign In did not return an id token');
+  }
+
+  const { data: supabaseData, error } = await supabase.auth.signInWithIdToken({
+    provider: 'google',
+    token: data.idToken,
+  });
+
+  if (error) throw error;
+  return supabaseData.session;
+}
+
 export async function signInWithApple() {
   const credential = await AppleAuthentication.signInAsync({
     requestedScopes: [
@@ -33,6 +55,16 @@ export async function signInWithApple() {
 
   if (!credential.identityToken) {
     throw new Error('Apple Sign In did not return an identity token');
+  }
+
+  // Debug: decode JWT payload to inspect aud/iss claims
+  if (__DEV__) {
+    try {
+      const payload = JSON.parse(
+        Buffer.from(credential.identityToken.split('.')[1], 'base64').toString('utf8')
+      );
+      console.log('[Apple JWT] aud:', payload.aud, '| iss:', payload.iss, '| sub:', payload.sub);
+    } catch {}
   }
 
   const { data, error } = await supabase.auth.signInWithIdToken({

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -94,7 +94,8 @@
     "errorPasswordMismatch": "Les mots de passe ne correspondent pas.",
     "errorRateLimit": "Trop de tentatives. Veuillez réessayer dans quelques minutes.",
     "errorGeneric": "Une erreur est survenue. Veuillez réessayer.",
-    "orEmail": "ou avec votre email"
+    "orEmail": "ou avec votre email",
+    "continueWithGoogle": "Continuer avec Google"
   },
   "recipes": {
     "title": "Recettes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-google-signin/google-signin": "^16.1.1",
         "@supabase/supabase-js": "^2.97.0",
         "expo": "~54.0.33",
         "expo-apple-authentication": "~8.0.8",
@@ -3734,6 +3735,22 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-google-signin/google-signin": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/@react-native-google-signin/google-signin/-/google-signin-16.1.1.tgz",
+      "integrity": "sha512-lcHBnZ7uvCJiWtGooKOklo/4okqszWvJ0BatW1UaIe+ynmpVpp1lyJkvv1Mj08d39k4soaWuhZVNKjD/RFL34Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": ">=52.0.40",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-google-signin/google-signin": "^16.1.1",
     "@supabase/supabase-js": "^2.97.0",
     "expo": "~54.0.33",
     "expo-apple-authentication": "~8.0.8",


### PR DESCRIPTION
## Summary

- **`signInWithGoogle()`** dans `authService` : `GoogleSignin.signIn()` → `idToken` → `supabase.signInWithIdToken({ provider: 'google' })`
- **`configureGoogleSignIn()`** appelé au mount du LoginScreen avec les client IDs depuis les variables d'env
- **Bouton Google** (blanc, iOS + Android) dans `login.tsx`, au-dessus du bouton Apple
- `SIGN_IN_CANCELLED` silencieux (user a annulé)
- Plugin `@react-native-google-signin/google-signin` configuré dans `app.json` avec `iosUrlScheme`
- `.env.example` mis à jour avec `EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID` et `EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID`

## Configuration Google Cloud Console requise (manuelle)

1. [console.cloud.google.com](https://console.cloud.google.com) → APIs & Services → Credentials → **+ Create Credentials → OAuth client ID**
2. Créer **2 client IDs** :
   - Type **iOS** → Bundle ID : `com.loicmonard.fridgy` → copier l'iOS Client ID
   - Type **Web application** → copier le Web Client ID
3. Renseigner les deux dans ton `.env` local + **EAS Secrets** pour les builds
4. Dans `app.json`, remplacer `$(GOOGLE_IOS_CLIENT_ID_REVERSED)` par la version inversée de l'iOS Client ID (ex: `123456-abc.apps.googleusercontent.com` → `com.googleusercontent.apps.123456-abc`)

## Supabase

Auth → Providers → **Google** → activer + coller le Web Client ID + Web Client Secret

## Test plan

- [ ] Bouton Google visible sur iOS et Android
- [ ] Tap → sheet Google native (pas browser)
- [ ] Annulation → aucune alerte
- [ ] Connexion réussie → session Supabase créée → redirect vers tabs
- [ ] Nécessite Dev Build (pas Expo Go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)