### PR TITLE
feat(foyer): foyer onboarding screen (#8)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,18 +5,25 @@ import { ActivityIndicator, View } from 'react-native';
 import { Stack, router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useAuth } from '@/features/auth/hooks/useAuth';
+import { useFoyer } from '@/features/foyer/hooks/useFoyer';
 
 export default function RootLayout() {
-  const { isAuthenticated, loading } = useAuth();
+  const { session, loading: authLoading } = useAuth();
+  const { hasFoyer, loading: foyerLoading } = useFoyer(session?.user.id);
+
+  const loading = authLoading || (!!session && foyerLoading);
 
   useEffect(() => {
     if (loading) return;
-    if (isAuthenticated) {
-      router.replace('/(tabs)');
-    } else {
+
+    if (!session) {
       router.replace('/(auth)/login');
+    } else if (!hasFoyer) {
+      router.replace('/onboarding/foyer');
+    } else {
+      router.replace('/(tabs)');
     }
-  }, [isAuthenticated, loading]);
+  }, [loading, session, hasFoyer]);
 
   if (loading) {
     return (
@@ -32,6 +39,7 @@ export default function RootLayout() {
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="(auth)" />
+        <Stack.Screen name="onboarding" />
         <Stack.Screen name="add" />
       </Stack>
     </>

--- a/app/onboarding/_layout.tsx
+++ b/app/onboarding/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from 'expo-router';
+
+export default function OnboardingLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="foyer" />
+    </Stack>
+  );
+}

--- a/app/onboarding/foyer.tsx
+++ b/app/onboarding/foyer.tsx
@@ -1,0 +1,241 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '@/lib/supabase';
+import { createFoyer, joinFoyer } from '@/features/foyer/services/foyerService';
+
+type Mode = 'choice' | 'create' | 'join';
+
+export default function FoyerOnboardingScreen() {
+  const { t } = useTranslation();
+  const [mode, setMode] = useState<Mode>('choice');
+  const [nom, setNom] = useState('');
+  const [code, setCode] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleCreate() {
+    if (!nom.trim()) {
+      Alert.alert(t('onboarding.errorNomRequired'));
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+      await createFoyer(nom, session.user.id);
+      router.replace('/(tabs)');
+    } catch {
+      Alert.alert(t('common.error'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleJoin() {
+    if (!code.trim()) {
+      Alert.alert(t('onboarding.errorCodeRequired'));
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+      await joinFoyer(code, session.user.id);
+      router.replace('/(tabs)');
+    } catch (err: any) {
+      if (err?.message === 'FOYER_NOT_FOUND') {
+        Alert.alert(t('onboarding.errorCodeInvalid'));
+      } else if (err?.message === 'ALREADY_MEMBER') {
+        router.replace('/(tabs)');
+      } else {
+        Alert.alert(t('common.error'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+
+          {/* Header */}
+          <View style={styles.header}>
+            {mode !== 'choice' && (
+              <TouchableOpacity onPress={() => setMode('choice')} style={styles.backBtn}>
+                <Text style={styles.backText}>‹</Text>
+              </TouchableOpacity>
+            )}
+            <Text style={styles.logo}>fridgy</Text>
+            <Text style={styles.title}>
+              {mode === 'choice' && t('onboarding.title')}
+              {mode === 'create' && t('onboarding.createTitle')}
+              {mode === 'join' && t('onboarding.joinTitle')}
+            </Text>
+            <Text style={styles.subtitle}>
+              {mode === 'choice' && t('onboarding.subtitle')}
+              {mode === 'create' && t('onboarding.createSubtitle')}
+              {mode === 'join' && t('onboarding.joinSubtitle')}
+            </Text>
+          </View>
+
+          {/* Choice */}
+          {mode === 'choice' && (
+            <View style={styles.choices}>
+              <TouchableOpacity style={styles.choiceCard} onPress={() => setMode('create')}>
+                <View style={[styles.choiceIcon, { backgroundColor: '#FFF3E0' }]}>
+                  <Ionicons name="home-outline" size={28} color="#FF8400" />
+                </View>
+                <View style={styles.choiceText}>
+                  <Text style={styles.choiceTitle}>{t('onboarding.createFoyer')}</Text>
+                  <Text style={styles.choiceDesc}>{t('onboarding.createFoyerDesc')}</Text>
+                </View>
+                <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.choiceCard} onPress={() => setMode('join')}>
+                <View style={[styles.choiceIcon, { backgroundColor: '#E3F2FD' }]}>
+                  <Ionicons name="people-outline" size={28} color="#1565C0" />
+                </View>
+                <View style={styles.choiceText}>
+                  <Text style={styles.choiceTitle}>{t('onboarding.joinFoyer')}</Text>
+                  <Text style={styles.choiceDesc}>{t('onboarding.joinFoyerDesc')}</Text>
+                </View>
+                <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* Create form */}
+          {mode === 'create' && (
+            <View style={styles.form}>
+              <View style={styles.field}>
+                <Text style={styles.label}>{t('onboarding.foyerName')}</Text>
+                <TextInput
+                  style={styles.input}
+                  value={nom}
+                  onChangeText={setNom}
+                  placeholder={t('onboarding.foyerNamePlaceholder')}
+                  placeholderTextColor="#9CA3AF"
+                  autoFocus
+                />
+              </View>
+              <TouchableOpacity
+                style={[styles.primaryBtn, loading && styles.btnDisabled]}
+                onPress={handleCreate}
+                disabled={loading}
+              >
+                {loading ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={styles.primaryBtnText}>{t('onboarding.createBtn')}</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          )}
+
+          {/* Join form */}
+          {mode === 'join' && (
+            <View style={styles.form}>
+              <View style={styles.field}>
+                <Text style={styles.label}>{t('onboarding.inviteCode')}</Text>
+                <TextInput
+                  style={styles.input}
+                  value={code}
+                  onChangeText={setCode}
+                  placeholder={t('onboarding.inviteCodePlaceholder')}
+                  placeholderTextColor="#9CA3AF"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  autoFocus
+                />
+              </View>
+              <Text style={styles.codeHint}>{t('onboarding.inviteCodeHint')}</Text>
+              <TouchableOpacity
+                style={[styles.primaryBtn, loading && styles.btnDisabled]}
+                onPress={handleJoin}
+                disabled={loading}
+              >
+                {loading ? (
+                  <ActivityIndicator color="#FFFFFF" />
+                ) : (
+                  <Text style={styles.primaryBtnText}>{t('onboarding.joinBtn')}</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+          )}
+
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: '#F2F3F0' },
+  flex: { flex: 1 },
+  content: { flexGrow: 1, paddingHorizontal: 24, paddingTop: 48, paddingBottom: 40, gap: 32 },
+  header: { gap: 10 },
+  backBtn: { marginBottom: 4 },
+  backText: { fontSize: 32, color: '#111111', lineHeight: 36 },
+  logo: { fontSize: 32, fontWeight: '800', color: '#FF8400', letterSpacing: -1 },
+  title: { fontSize: 26, fontWeight: '700', color: '#111111' },
+  subtitle: { fontSize: 15, color: '#6B7280', lineHeight: 22 },
+  choices: { gap: 14 },
+  choiceCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 18,
+  },
+  choiceIcon: {
+    width: 52,
+    height: 52,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  choiceText: { flex: 1 },
+  choiceTitle: { fontSize: 16, fontWeight: '600', color: '#111111' },
+  choiceDesc: { fontSize: 13, color: '#6B7280', marginTop: 2 },
+  form: { gap: 16 },
+  field: { gap: 6 },
+  label: { fontSize: 13, fontWeight: '600', color: '#374151', textTransform: 'uppercase', letterSpacing: 0.5 },
+  input: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 15,
+    color: '#111111',
+  },
+  codeHint: { fontSize: 13, color: '#9CA3AF', marginTop: -8 },
+  primaryBtn: {
+    backgroundColor: '#FF8400',
+    borderRadius: 14,
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  btnDisabled: { opacity: 0.6 },
+  primaryBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+});

--- a/app/onboarding/foyer.tsx
+++ b/app/onboarding/foyer.tsx
@@ -38,7 +38,8 @@ export default function FoyerOnboardingScreen() {
       if (!session) return;
       await createFoyer(nom, session.user.id);
       router.replace('/(tabs)');
-    } catch {
+    } catch (err: any) {
+      console.error('[handleCreate]', err);
       Alert.alert(t('common.error'));
     } finally {
       setLoading(false);

--- a/features/foyer/hooks/useFoyer.ts
+++ b/features/foyer/hooks/useFoyer.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { getUserFoyer } from '@/features/foyer/services/foyerService';
+
+export interface FoyerInfo {
+  id: string;
+  nom: string;
+}
+
+export function useFoyer(userId: string | undefined) {
+  const [foyer, setFoyer] = useState<FoyerInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!userId) {
+      setFoyer(null);
+      setLoading(false);
+      return;
+    }
+
+    getUserFoyer(userId)
+      .then(setFoyer)
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  return { foyer, loading, hasFoyer: !!foyer };
+}

--- a/features/foyer/services/foyerService.ts
+++ b/features/foyer/services/foyerService.ts
@@ -1,0 +1,55 @@
+import { supabase } from '@/lib/supabase';
+
+export async function getUserFoyer(userId: string): Promise<{ id: string; nom: string } | null> {
+  const { data } = await supabase
+    .from('foyer_membres')
+    .select('foyer_id, foyers(id, nom)')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (!data) return null;
+  const foyer = data.foyers as unknown as { id: string; nom: string } | null;
+  return foyer ?? null;
+}
+
+export async function createFoyer(nom: string, userId: string): Promise<string> {
+  // Insert foyer
+  const { data: foyer, error: foyerError } = await supabase
+    .from('foyers')
+    .insert({ nom: nom.trim(), created_by: userId })
+    .select('id')
+    .single();
+
+  if (foyerError) throw foyerError;
+
+  // Add user as admin
+  const { error: membreError } = await supabase
+    .from('foyer_membres')
+    .insert({ foyer_id: foyer.id, user_id: userId, role: 'admin' });
+
+  if (membreError) throw membreError;
+
+  return foyer.id as string;
+}
+
+export async function joinFoyer(foyerId: string, userId: string): Promise<void> {
+  // Check foyer exists
+  const { data: foyer, error: checkError } = await supabase
+    .from('foyers')
+    .select('id')
+    .eq('id', foyerId.trim())
+    .maybeSingle();
+
+  if (checkError) throw checkError;
+  if (!foyer) throw new Error('FOYER_NOT_FOUND');
+
+  // Add user as membre
+  const { error } = await supabase
+    .from('foyer_membres')
+    .insert({ foyer_id: foyerId.trim(), user_id: userId, role: 'membre' });
+
+  if (error) {
+    if (error.code === '23505') throw new Error('ALREADY_MEMBER');
+    throw error;
+  }
+}

--- a/features/foyer/services/foyerService.ts
+++ b/features/foyer/services/foyerService.ts
@@ -13,43 +13,24 @@ export async function getUserFoyer(userId: string): Promise<{ id: string; nom: s
 }
 
 export async function createFoyer(nom: string, userId: string): Promise<string> {
-  // Insert foyer
-  const { data: foyer, error: foyerError } = await supabase
-    .from('foyers')
-    .insert({ nom: nom.trim(), created_by: userId })
-    .select('id')
-    .single();
+  const { data, error } = await supabase.rpc('create_foyer', {
+    p_nom: nom.trim(),
+    p_user_id: userId,
+  });
 
-  if (foyerError) throw foyerError;
-
-  // Add user as admin
-  const { error: membreError } = await supabase
-    .from('foyer_membres')
-    .insert({ foyer_id: foyer.id, user_id: userId, role: 'admin' });
-
-  if (membreError) throw membreError;
-
-  return foyer.id as string;
+  if (error) throw error;
+  return data as string;
 }
 
 export async function joinFoyer(foyerId: string, userId: string): Promise<void> {
-  // Check foyer exists
-  const { data: foyer, error: checkError } = await supabase
-    .from('foyers')
-    .select('id')
-    .eq('id', foyerId.trim())
-    .maybeSingle();
-
-  if (checkError) throw checkError;
-  if (!foyer) throw new Error('FOYER_NOT_FOUND');
-
-  // Add user as membre
-  const { error } = await supabase
-    .from('foyer_membres')
-    .insert({ foyer_id: foyerId.trim(), user_id: userId, role: 'membre' });
+  const { error } = await supabase.rpc('join_foyer', {
+    p_foyer_id: foyerId.trim(),
+    p_user_id: userId,
+  });
 
   if (error) {
-    if (error.code === '23505') throw new Error('ALREADY_MEMBER');
+    if (error.message === 'FOYER_NOT_FOUND') throw new Error('FOYER_NOT_FOUND');
+    if (error.message === 'ALREADY_MEMBER') throw new Error('ALREADY_MEMBER');
     throw error;
   }
 }

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -97,6 +97,28 @@
     "orEmail": "ou avec votre email",
     "continueWithGoogle": "Continuer avec Google"
   },
+  "onboarding": {
+    "title": "Bienvenue sur Fridgy",
+    "subtitle": "Commencez par créer votre foyer ou rejoindre celui d'un proche.",
+    "createTitle": "Créer un foyer",
+    "createSubtitle": "Donnez un nom à votre foyer pour commencer à gérer votre stock.",
+    "joinTitle": "Rejoindre un foyer",
+    "joinSubtitle": "Saisissez le code d'invitation partagé par un membre du foyer.",
+    "createFoyer": "Créer un foyer",
+    "createFoyerDesc": "Nouveau foyer, nouvelles habitudes",
+    "joinFoyer": "Rejoindre un foyer",
+    "joinFoyerDesc": "Vous avez un code d'invitation ?",
+    "foyerName": "Nom du foyer",
+    "foyerNamePlaceholder": "Ex : Famille Dupont",
+    "createBtn": "Créer le foyer",
+    "inviteCode": "Code d'invitation",
+    "inviteCodePlaceholder": "Collez le code ici",
+    "inviteCodeHint": "Le code vous a été partagé par un membre du foyer.",
+    "joinBtn": "Rejoindre le foyer",
+    "errorNomRequired": "Le nom du foyer est obligatoire.",
+    "errorCodeRequired": "Le code d'invitation est obligatoire.",
+    "errorCodeInvalid": "Ce code d'invitation est invalide ou expiré."
+  },
   "recipes": {
     "title": "Recettes",
     "emptyState": "Aucune recette trouvée",

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -148,22 +148,44 @@ ALTER TABLE ingredient_synonymes ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "profiles: own row" ON profiles
   FOR ALL USING (auth.uid() = id);
 
--- foyers : accès aux membres du foyer
-CREATE POLICY "foyers: members only" ON foyers
-  FOR ALL USING (
-    id IN (SELECT foyer_id FROM foyer_membres WHERE user_id = auth.uid())
-  );
+-- Helper : retourne les foyer_ids de l'utilisateur sans déclencher RLS (évite la récursion)
+CREATE OR REPLACE FUNCTION get_user_foyer_ids(uid uuid)
+RETURNS SETOF uuid
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT foyer_id FROM foyer_membres WHERE user_id = uid;
+$$;
 
--- foyer_membres : visibilité pour les membres du même foyer
-CREATE POLICY "foyer_membres: same foyer" ON foyer_membres
-  FOR ALL USING (
-    foyer_id IN (SELECT foyer_id FROM foyer_membres WHERE user_id = auth.uid())
-  );
+-- foyers : INSERT libre (authentifié), SELECT/UPDATE/DELETE via helper
+CREATE POLICY "foyers: insert authenticated" ON foyers
+  FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+CREATE POLICY "foyers: members select" ON foyers
+  FOR SELECT USING (id IN (SELECT get_user_foyer_ids(auth.uid())));
+
+CREATE POLICY "foyers: members update" ON foyers
+  FOR UPDATE USING (id IN (SELECT get_user_foyer_ids(auth.uid())));
+
+CREATE POLICY "foyers: members delete" ON foyers
+  FOR DELETE USING (id IN (SELECT get_user_foyer_ids(auth.uid())));
+
+-- foyer_membres : INSERT sur sa propre ligne, SELECT/DELETE via helper
+CREATE POLICY "foyer_membres: insert own" ON foyer_membres
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "foyer_membres: select same foyer" ON foyer_membres
+  FOR SELECT USING (foyer_id IN (SELECT get_user_foyer_ids(auth.uid())));
+
+CREATE POLICY "foyer_membres: delete same foyer" ON foyer_membres
+  FOR DELETE USING (foyer_id IN (SELECT get_user_foyer_ids(auth.uid())));
 
 -- stock_items : accès par foyer
 CREATE POLICY "stock_items: foyer members" ON stock_items
   FOR ALL USING (
-    foyer_id IN (SELECT foyer_id FROM foyer_membres WHERE user_id = auth.uid())
+    foyer_id IN (SELECT get_user_foyer_ids(auth.uid()))
   );
 
 -- produits : lecture publique (cache partagé), écriture authentifiée
@@ -197,7 +219,7 @@ CREATE POLICY "ingredient_synonymes: read all" ON ingredient_synonymes
 -- foyer_recettes_favorites : accès par foyer
 CREATE POLICY "favorites: foyer members" ON foyer_recettes_favorites
   FOR ALL USING (
-    foyer_id IN (SELECT foyer_id FROM foyer_membres WHERE user_id = auth.uid())
+    foyer_id IN (SELECT get_user_foyer_ids(auth.uid()))
   );
 
 -- ============================================================


### PR DESCRIPTION
## Summary

- Add `foyerService.ts` with `getUserFoyer`, `createFoyer`, `joinFoyer`
- Add `useFoyer` hook returning `{ foyer, loading, hasFoyer }`
- Update `app/_layout.tsx` for 3-way routing: no session → login, session + no foyer → onboarding, session + foyer → tabs
- Add `app/onboarding/foyer.tsx` with choice/create/join modes
- Add `onboarding.*` i18n keys to `fr.json`

## Test plan

- [ ] New user after sign up → redirected to onboarding foyer screen
- [ ] Create foyer → enters app tabs
- [ ] Join foyer with valid UUID → enters app tabs
- [ ] Join foyer with invalid UUID → error message shown
- [ ] User with existing foyer → redirected directly to tabs

Refs #8