### PR TITLE
fix(foyer): prevent duplicate foyer creation on each app launch

### DIFF
--- a/features/foyer/hooks/useFoyer.ts
+++ b/features/foyer/hooks/useFoyer.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase';
 import { getUserFoyer } from '@/features/foyer/services/foyerService';
 
 export interface FoyerInfo {
@@ -9,19 +8,32 @@ export interface FoyerInfo {
 
 export function useFoyer(userId: string | undefined) {
   const [foyer, setFoyer] = useState<FoyerInfo | null>(null);
-  const [loading, setLoading] = useState(true);
+  // tracks which userId the current foyer state was fetched for
+  const [fetchedFor, setFetchedFor] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     if (!userId) {
       setFoyer(null);
-      setLoading(false);
+      setFetchedFor(undefined);
       return;
     }
 
     getUserFoyer(userId)
-      .then(setFoyer)
-      .finally(() => setLoading(false));
+      .then((result) => {
+        setFoyer(result);
+        setFetchedFor(userId);
+      })
+      .catch(() => {
+        setFoyer(null);
+        setFetchedFor(userId);
+      });
   }, [userId]);
+
+  // loading is true whenever userId is set but we haven't finished fetching for it yet.
+  // this is computed at render time so _layout.tsx sees loading=true immediately when
+  // userId transitions from undefined to a real value, avoiding the race condition where
+  // hasFoyer=false triggers createFoyer before the initial fetch completes.
+  const loading = userId ? fetchedFor !== userId : false;
 
   return { foyer, loading, hasFoyer: !!foyer };
 }


### PR DESCRIPTION
## Problème

Race condition dans `useFoyer` : quand la session se résolvait, `userId` passait de `undefined` à une vraie valeur en cours de render. L'effet du hook n'avait pas encore tourné, donc il retournait encore `loading=false` / `hasFoyer=false`. `_layout.tsx` déclenchait alors `createFoyer()` avant même que le premier fetch parte — créant un nouveau foyer à chaque lancement.

## Fix

Derivation du `loading` au moment du render via `fetchedFor` — une variable d'état qui traque pour quel `userId` les données foyer ont été fetchées. Dès que `userId` est défini et ne correspond pas à `fetchedFor`, `loading=true` immédiatement (même render), ce qui bloque le chemin `createFoyer` dans `_layout.tsx`.

## Test plan

- [ ] Lancer l'app une première fois (nouvel utilisateur) → 1 seul foyer créé
- [ ] Relancer l'app → aucun nouveau foyer créé, redirection directe vers les tabs
- [ ] Vérifier en base que l'utilisateur n'a toujours qu'un seul foyer après plusieurs lancements

Refs #43