### PR TITLE
feat(scanning): implement receipt scan pipeline (OCR + Gemini + confirm)

### DIFF
--- a/app/(tabs)/add.tsx
+++ b/app/(tabs)/add.tsx
@@ -22,7 +22,7 @@ export default function AddScreen() {
           </View>
           <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
         </TouchableOpacity>
-        <TouchableOpacity style={styles.option}>
+        <TouchableOpacity style={styles.option} onPress={() => router.push('/add/scan-receipt')}>
           <View style={[styles.iconBox, { backgroundColor: '#E3F2FD' }]}>
             <Ionicons name="receipt-outline" size={26} color="#1565C0" />
           </View>

--- a/app/add/_layout.tsx
+++ b/app/add/_layout.tsx
@@ -5,6 +5,8 @@ export default function AddLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="scan-barcode" />
       <Stack.Screen name="product-confirm" />
+      <Stack.Screen name="scan-receipt" />
+      <Stack.Screen name="receipt-confirm" />
     </Stack>
   );
 }

--- a/app/add/receipt-confirm.tsx
+++ b/app/add/receipt-confirm.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useLocalSearchParams } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '@/lib/supabase';
+import { addReceiptItemsToStock } from '@/features/stock/services/stockService';
+import type { Lieu, ReceiptItemDraft, ReceiptProduct } from '@/features/scanning/types';
+
+const LIEUX: { value: Lieu; label: string; icon: string }[] = [
+  { value: 'frigo', label: 'productConfirm.frigo', icon: 'snow-outline' },
+  { value: 'placard', label: 'productConfirm.placard', icon: 'cube-outline' },
+  { value: 'congelateur', label: 'productConfirm.congelateur', icon: 'thermometer-outline' },
+];
+
+interface EditableItem {
+  id: string;
+  nom: string;
+  quantite: string;
+  unite: string;
+  ingredientTag?: string;
+  dureeConservationJours?: number;
+}
+
+export default function ReceiptConfirmScreen() {
+  const { t } = useTranslation();
+  const params = useLocalSearchParams<{ items: string }>();
+
+  const initial: ReceiptProduct[] = JSON.parse(params.items ?? '[]');
+
+  const [editableItems, setEditableItems] = useState<EditableItem[]>(
+    initial.map((item, i) => ({
+      id: String(i),
+      nom: item.nom,
+      quantite: String(item.quantiteEstimee ?? 1),
+      unite: item.unite ?? 'unite',
+      ingredientTag: item.ingredientTag,
+      dureeConservationJours: item.dureeConservationJours,
+    })),
+  );
+  const [lieu, setLieu] = useState<Lieu>('frigo');
+  const [saving, setSaving] = useState(false);
+
+  function updateItem(id: string, patch: Partial<EditableItem>) {
+    setEditableItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...patch } : item)));
+  }
+
+  function removeItem(id: string) {
+    setEditableItems((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  async function handleSaveAll() {
+    const validItems = editableItems.filter((item) => item.nom.trim());
+    if (validItems.length === 0) {
+      Alert.alert(t('receiptConfirm.errorNoItems'));
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) return;
+
+      const { data: membre } = await supabase
+        .from('foyer_membres')
+        .select('foyer_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+
+      if (!membre) {
+        Alert.alert(t('productConfirm.errorNoFoyer'));
+        return;
+      }
+
+      const drafts: ReceiptItemDraft[] = validItems.map((item) => ({
+        nom: item.nom.trim(),
+        ingredientTag: item.ingredientTag,
+        quantite: parseFloat(item.quantite.replace(',', '.')) || 1,
+        unite: item.unite,
+        dureeConservationJours: item.dureeConservationJours,
+        lieu,
+      }));
+
+      await addReceiptItemsToStock(drafts, membre.foyer_id as string, session.user.id);
+      router.replace('/(tabs)/stock');
+    } catch {
+      Alert.alert(t('common.error'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* Header */}
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+            <Ionicons name="arrow-back" size={24} color="#111111" />
+          </TouchableOpacity>
+          <View style={styles.flex}>
+            <Text style={styles.headerTitle}>{t('receiptConfirm.title')}</Text>
+            <Text style={styles.headerSubtitle}>
+              {t('receiptConfirm.itemCount', { count: editableItems.length })}
+            </Text>
+          </View>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          {/* Lieu global */}
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>{t('receiptConfirm.lieu')}</Text>
+            <View style={styles.lieuRow}>
+              {LIEUX.map((l) => (
+                <TouchableOpacity
+                  key={l.value}
+                  style={[styles.lieuBtn, lieu === l.value && styles.lieuBtnActive]}
+                  onPress={() => setLieu(l.value)}
+                >
+                  <Ionicons
+                    name={l.icon as never}
+                    size={18}
+                    color={lieu === l.value ? '#FF8400' : '#6B7280'}
+                  />
+                  <Text style={[styles.lieuBtnText, lieu === l.value && styles.lieuBtnTextActive]}>
+                    {t(l.label)}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Items list */}
+          {editableItems.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Ionicons name="receipt-outline" size={40} color="#D1D5DB" />
+              <Text style={styles.emptyText}>{t('receiptConfirm.empty')}</Text>
+            </View>
+          ) : (
+            <View style={styles.itemsList}>
+              {editableItems.map((item) => (
+                <View key={item.id} style={styles.itemCard}>
+                  <View style={styles.itemRow}>
+                    <TextInput
+                      style={[styles.input, styles.inputNom]}
+                      value={item.nom}
+                      onChangeText={(text) => updateItem(item.id, { nom: text })}
+                      placeholder={t('productConfirm.nomPlaceholder')}
+                      placeholderTextColor="#9CA3AF"
+                    />
+                    <TouchableOpacity
+                      onPress={() => removeItem(item.id)}
+                      style={styles.removeBtn}
+                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    >
+                      <Ionicons name="close-circle" size={20} color="#EF4444" />
+                    </TouchableOpacity>
+                  </View>
+                  <View style={styles.itemRow}>
+                    <TextInput
+                      style={[styles.input, styles.inputQty]}
+                      value={item.quantite}
+                      onChangeText={(text) => updateItem(item.id, { quantite: text })}
+                      keyboardType="decimal-pad"
+                    />
+                    <TextInput
+                      style={[styles.input, styles.inputUnite]}
+                      value={item.unite}
+                      onChangeText={(text) => updateItem(item.id, { unite: text })}
+                      autoCapitalize="none"
+                    />
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+
+          {/* Save button */}
+          <TouchableOpacity
+            style={[
+              styles.saveBtn,
+              (saving || editableItems.length === 0) && styles.saveBtnDisabled,
+            ]}
+            onPress={handleSaveAll}
+            disabled={saving || editableItems.length === 0}
+          >
+            {saving ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.saveBtnText}>
+                {t('receiptConfirm.addAll', { count: editableItems.length })}
+              </Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: '#F2F3F0' },
+  flex: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#F2F3F0',
+  },
+  backBtn: { padding: 4 },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#111111' },
+  headerSubtitle: { fontSize: 13, color: '#6B7280', marginTop: 1 },
+  content: { paddingHorizontal: 20, paddingBottom: 40, gap: 20 },
+  section: { gap: 8 },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#374151',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  lieuRow: { flexDirection: 'row', gap: 10 },
+  lieuBtn: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
+  lieuBtnText: { fontSize: 12, color: '#6B7280' },
+  lieuBtnTextActive: { color: '#FF8400', fontWeight: '600' },
+  itemsList: { gap: 10 },
+  itemCard: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 12,
+    gap: 8,
+  },
+  itemRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  input: {
+    backgroundColor: '#F9FAFB',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    fontSize: 14,
+    color: '#111111',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  inputNom: { flex: 1 },
+  inputQty: { width: 64 },
+  inputUnite: { width: 80 },
+  removeBtn: { padding: 2 },
+  emptyState: {
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 40,
+  },
+  emptyText: { fontSize: 15, color: '#9CA3AF', textAlign: 'center' },
+  saveBtn: {
+    backgroundColor: '#FF8400',
+    borderRadius: 14,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  saveBtnDisabled: { opacity: 0.5 },
+  saveBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+});

--- a/app/add/scan-receipt.tsx
+++ b/app/add/scan-receipt.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { router } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTranslation } from 'react-i18next';
+import { useReceiptScan } from '@/features/scanning/hooks/useReceiptScan';
+
+export default function ScanReceiptScreen() {
+  const { t } = useTranslation();
+  const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView>(null);
+  const [capturing, setCapturing] = useState(false);
+  const { step, items, error, processPhoto, reset } = useReceiptScan();
+
+  const processing = step === 'ocr' || step === 'llm';
+
+  // Navigate once processing is done
+  useEffect(() => {
+    if (step === 'done') {
+      if (items.length === 0) {
+        Alert.alert(t('receiptScan.errorTitle'), t('receiptScan.errorEmpty'), [
+          { text: t('common.retry'), onPress: reset },
+        ]);
+        return;
+      }
+      router.replace({
+        pathname: '/add/receipt-confirm',
+        params: { items: JSON.stringify(items) },
+      });
+      reset();
+    } else if (step === 'error') {
+      const msg = error === 'OCR_FAILED' ? t('receiptScan.errorOcr') : t('receiptScan.errorLlm');
+      Alert.alert(t('receiptScan.errorTitle'), msg, [
+        { text: t('common.retry'), onPress: reset },
+      ]);
+    }
+  }, [step]);
+
+  async function handleCapture() {
+    if (capturing || processing) return;
+    setCapturing(true);
+    try {
+      const photo = await cameraRef.current?.takePictureAsync({ quality: 0.85 });
+      if (photo?.uri) {
+        await processPhoto(photo.uri);
+      }
+    } finally {
+      setCapturing(false);
+    }
+  }
+
+  if (!permission) {
+    return (
+      <SafeAreaView style={styles.centered}>
+        <ActivityIndicator color="#FF8400" />
+      </SafeAreaView>
+    );
+  }
+
+  if (!permission.granted) {
+    return (
+      <SafeAreaView style={styles.centered}>
+        <Ionicons name="camera-outline" size={48} color="#9CA3AF" />
+        <Text style={styles.permissionText}>{t('scan.cameraPermission')}</Text>
+        <TouchableOpacity style={styles.permissionBtn} onPress={requestPermission}>
+          <Text style={styles.permissionBtnText}>{t('scan.grantPermission')}</Text>
+        </TouchableOpacity>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <CameraView ref={cameraRef} style={StyleSheet.absoluteFill} facing="back" />
+
+      {/* Header */}
+      <SafeAreaView style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+          <Ionicons name="arrow-back" size={24} color="#FFFFFF" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>{t('receiptScan.title')}</Text>
+      </SafeAreaView>
+
+      {/* Hint */}
+      <View style={styles.hintContainer}>
+        <Text style={styles.hint}>{t('receiptScan.hint')}</Text>
+      </View>
+
+      {/* Capture button */}
+      <SafeAreaView edges={['bottom']} style={styles.footer}>
+        <TouchableOpacity
+          style={[styles.captureBtn, (capturing || processing) && styles.captureBtnDisabled]}
+          onPress={handleCapture}
+          disabled={capturing || processing}
+        >
+          <Ionicons name="camera" size={28} color="#FFFFFF" />
+        </TouchableOpacity>
+      </SafeAreaView>
+
+      {/* Processing overlay */}
+      {processing && (
+        <View style={styles.overlay}>
+          <ActivityIndicator size="large" color="#FF8400" />
+          <Text style={styles.overlayText}>
+            {step === 'ocr' ? t('receiptScan.readingText') : t('receiptScan.analyzing')}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#000' },
+  centered: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+    backgroundColor: '#F2F3F0',
+  },
+  permissionText: { fontSize: 15, color: '#6B7280', textAlign: 'center', paddingHorizontal: 40 },
+  permissionBtn: {
+    backgroundColor: '#FF8400',
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 12,
+  },
+  permissionBtnText: { color: '#FFFFFF', fontWeight: '600', fontSize: 15 },
+  header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingBottom: 12,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  backBtn: { padding: 4 },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#FFFFFF' },
+  hintContainer: {
+    position: 'absolute',
+    top: '35%',
+    left: 24,
+    right: 24,
+    alignItems: 'center',
+  },
+  hint: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    textAlign: 'center',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    paddingBottom: 32,
+  },
+  captureBtn: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: '#FF8400',
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+  captureBtnDisabled: { opacity: 0.5 },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.65)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 16,
+  },
+  overlayText: { color: '#FFFFFF', fontSize: 16, fontWeight: '500' },
+});

--- a/features/scanning/hooks/useReceiptScan.ts
+++ b/features/scanning/hooks/useReceiptScan.ts
@@ -1,0 +1,54 @@
+import { useRef, useState } from 'react';
+import MlkitOcr from 'react-native-mlkit-ocr';
+import { parseReceiptOcr } from '../services/receiptService';
+import type { ReceiptProduct } from '../types';
+
+export type ReceiptScanStep = 'idle' | 'ocr' | 'llm' | 'done' | 'error';
+
+export function useReceiptScan() {
+  const [step, setStep] = useState<ReceiptScanStep>('idle');
+  const [items, setItems] = useState<ReceiptProduct[]>([]);
+  const [error, setError] = useState<'OCR_FAILED' | 'LLM_FAILED' | null>(null);
+  const processingRef = useRef(false);
+
+  async function processPhoto(imageUri: string) {
+    if (processingRef.current) return;
+    processingRef.current = true;
+    setError(null);
+
+    try {
+      // Step 1 — on-device OCR via MLKit
+      setStep('ocr');
+      const blocks = await MlkitOcr.detectFromUri(imageUri);
+      const ocrText = blocks.map((b) => b.text).join('\n').trim();
+
+      if (!ocrText) {
+        setError('OCR_FAILED');
+        setStep('error');
+        return;
+      }
+
+      // Step 2 — Supabase Edge Function → Gemini Flash
+      setStep('llm');
+      const parsed = await parseReceiptOcr(ocrText);
+      setItems(parsed);
+      setStep('done');
+    } catch (err) {
+      console.error('[useReceiptScan]', err);
+      const isOcrStep = step === 'ocr';
+      setError(isOcrStep ? 'OCR_FAILED' : 'LLM_FAILED');
+      setStep('error');
+    } finally {
+      processingRef.current = false;
+    }
+  }
+
+  function reset() {
+    setStep('idle');
+    setItems([]);
+    setError(null);
+    processingRef.current = false;
+  }
+
+  return { step, items, error, processPhoto, reset };
+}

--- a/features/scanning/services/receiptService.ts
+++ b/features/scanning/services/receiptService.ts
@@ -1,0 +1,27 @@
+import { supabase } from '@/lib/supabase';
+import type { ReceiptProduct } from '../types';
+
+interface EdgeFunctionItem {
+  nom: string;
+  ingredient_tag: string | null;
+  quantite_estimee: number;
+  unite: string;
+  duree_conservation_jours: number | null;
+}
+
+export async function parseReceiptOcr(ocrText: string): Promise<ReceiptProduct[]> {
+  const { data, error } = await supabase.functions.invoke('parse-receipt', {
+    body: { ocrText },
+  });
+
+  if (error) throw error;
+  if (data?.error) throw new Error(data.error);
+
+  return (data.items as EdgeFunctionItem[]).map((item) => ({
+    nom: item.nom,
+    ingredientTag: item.ingredient_tag ?? undefined,
+    quantiteEstimee: item.quantite_estimee ?? 1,
+    unite: item.unite ?? 'unite',
+    dureeConservationJours: item.duree_conservation_jours ?? undefined,
+  }));
+}

--- a/features/scanning/types.ts
+++ b/features/scanning/types.ts
@@ -32,6 +32,15 @@ export interface ReceiptProduct {
 export type Lieu = 'frigo' | 'congelateur' | 'placard';
 export type Unite = 'pièce' | 'g' | 'kg' | 'ml' | 'L' | 'boîte' | 'sachet';
 
+export interface ReceiptItemDraft {
+  nom: string;
+  ingredientTag?: string;
+  quantite: number;
+  unite: string;
+  dureeConservationJours?: number;
+  lieu: Lieu;
+}
+
 export interface StockItemDraft {
   scannedProduct: ScannedProduct;
   quantite: number;

--- a/features/stock/services/stockService.ts
+++ b/features/stock/services/stockService.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@/lib/supabase';
-import type { ScannedProduct, StockItemDraft } from '@/features/scanning/types';
+import type { ReceiptItemDraft, ScannedProduct, StockItemDraft } from '@/features/scanning/types';
 
 async function upsertProduit(scannedProduct: ScannedProduct): Promise<string> {
   const { ean, nom, marque, categorie, imageUrl } = scannedProduct;
@@ -52,4 +52,39 @@ export async function addToStock(
   });
 
   if (error) throw error;
+}
+
+export async function addReceiptItemsToStock(
+  items: ReceiptItemDraft[],
+  foyerId: string,
+  addedBy: string,
+): Promise<void> {
+  for (const item of items) {
+    const { data: produit, error: produitError } = await supabase
+      .from('produits')
+      .insert({ nom: item.nom, source: 'llm_ticket' })
+      .select('id')
+      .single();
+
+    if (produitError) throw produitError;
+
+    const expiryDate = item.dureeConservationJours
+      ? new Date(Date.now() + item.dureeConservationJours * 86_400_000)
+          .toISOString()
+          .split('T')[0]
+      : null;
+
+    const { error: stockError } = await supabase.from('stock_items').insert({
+      foyer_id: foyerId,
+      added_by: addedBy,
+      produit_id: produit.id,
+      ingredient_tag: item.ingredientTag ?? null,
+      quantite: item.quantite,
+      unite: item.unite,
+      date_peremption: expiryDate,
+      lieu: item.lieu,
+    });
+
+    if (stockError) throw stockError;
+  }
 }

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -97,6 +97,26 @@
     "orEmail": "ou avec votre email",
     "continueWithGoogle": "Continuer avec Google"
   },
+  "receiptScan": {
+    "title": "Scanner un ticket",
+    "hint": "Cadrez le ticket de caisse en entier",
+    "readingText": "Lecture du ticket…",
+    "analyzing": "Analyse en cours…",
+    "errorTitle": "Problème de lecture",
+    "errorOcr": "Impossible de lire le ticket. Vérifiez l'éclairage et réessayez.",
+    "errorLlm": "L'analyse a échoué. Réessayez.",
+    "errorEmpty": "Aucun produit alimentaire détecté. Réessayez."
+  },
+  "receiptConfirm": {
+    "title": "Vérifier les produits",
+    "itemCount": "{{count}} produit détecté",
+    "itemCount_plural": "{{count}} produits détectés",
+    "lieu": "Rangement (pour tous)",
+    "addAll": "Ajouter {{count}} produit au stock",
+    "addAll_plural": "Ajouter {{count}} produits au stock",
+    "empty": "Aucun produit. Revenez en arrière et réessayez.",
+    "errorNoItems": "Aucun produit à ajouter."
+  },
   "recipes": {
     "title": "Recettes",
     "emptyState": "Aucune recette trouvée",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "19.1.0",
         "react-i18next": "^16.5.4",
         "react-native": "0.81.5",
+        "react-native-mlkit-ocr": "^0.3.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-url-polyfill": "^3.0.0"
@@ -14450,6 +14451,16 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
       "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-mlkit-ocr": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-mlkit-ocr/-/react-native-mlkit-ocr-0.3.0.tgz",
+      "integrity": "sha512-8oNJwNMGsUup41nWlKA01iW6xiNkCcXM3ANDsOKKijvsrd3eWNs7kL0Yhpt3Cq64zSyjoeqkdTdOCDiI6Pv6KA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "19.1.0",
     "react-i18next": "^16.5.4",
     "react-native": "0.81.5",
+    "react-native-mlkit-ocr": "^0.3.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-url-polyfill": "^3.0.0"


### PR DESCRIPTION
## Summary

Pipeline complet scan ticket de caisse :

1. **`scan-receipt.tsx`** — écran caméra, prend une photo, déclenche le pipeline
2. **`useReceiptScan`** hook — machine à états (`idle → ocr → llm → done/error`), gère MLKit + Edge Function
3. **`receiptService.ts`** — `supabase.functions.invoke('parse-receipt', { body: { ocrText } })`
4. **`receipt-confirm.tsx`** — liste éditable (nom, quantité, unité par item + lieu global), bulk insert
5. **`addReceiptItemsToStock`** dans `stockService.ts` — crée un `produit` (`source: 'llm_ticket'`) + `stock_item` pour chaque ligne
6. Bouton "Scanner un ticket" dans l'onglet Ajouter désormais actif

## Dépendance native

`react-native-mlkit-ocr@0.3.0` est un module natif — **rebuild du dev client requis** après merge.

## Test plan

- [ ] Rebuild dev client (`eas build --profile development`)
- [ ] Prendre en photo un ticket Carrefour/Leclerc → produits détectés
- [ ] Modifier un nom/quantité dans l'écran de confirmation → sauvegardé correctement
- [ ] Supprimer un item → retiré de la liste
- [ ] Valider → produits visibles dans l'onglet Stock
- [ ] Ticket illisible → message d'erreur + bouton Réessayer
- [ ] Ticket sans produits alimentaires → message "aucun produit détecté"

Refs #17