### PR TITLE
fix(scanning): replace MLKit OCR with Gemini Vision to fix iOS build

### DIFF
--- a/app/add/scan-receipt.tsx
+++ b/app/add/scan-receipt.tsx
@@ -21,7 +21,7 @@ export default function ScanReceiptScreen() {
   const [capturing, setCapturing] = useState(false);
   const { step, items, error, processPhoto, reset } = useReceiptScan();
 
-  const processing = step === 'ocr' || step === 'llm';
+  const processing = step === 'processing';
 
   // Navigate once processing is done
   useEffect(() => {
@@ -38,8 +38,7 @@ export default function ScanReceiptScreen() {
       });
       reset();
     } else if (step === 'error') {
-      const msg = error === 'OCR_FAILED' ? t('receiptScan.errorOcr') : t('receiptScan.errorLlm');
-      Alert.alert(t('receiptScan.errorTitle'), msg, [
+      Alert.alert(t('receiptScan.errorTitle'), t('receiptScan.errorLlm'), [
         { text: t('common.retry'), onPress: reset },
       ]);
     }
@@ -49,9 +48,9 @@ export default function ScanReceiptScreen() {
     if (capturing || processing) return;
     setCapturing(true);
     try {
-      const photo = await cameraRef.current?.takePictureAsync({ quality: 0.85 });
-      if (photo?.uri) {
-        await processPhoto(photo.uri);
+      const photo = await cameraRef.current?.takePictureAsync({ quality: 0.6, base64: true });
+      if (photo?.base64) {
+        await processPhoto(photo.base64, 'image/jpeg');
       }
     } finally {
       setCapturing(false);
@@ -110,9 +109,7 @@ export default function ScanReceiptScreen() {
       {processing && (
         <View style={styles.overlay}>
           <ActivityIndicator size="large" color="#FF8400" />
-          <Text style={styles.overlayText}>
-            {step === 'ocr' ? t('receiptScan.readingText') : t('receiptScan.analyzing')}
-          </Text>
+          <Text style={styles.overlayText}>{t('receiptScan.analyzing')}</Text>
         </View>
       )}
     </View>

--- a/features/scanning/hooks/useReceiptScan.ts
+++ b/features/scanning/hooks/useReceiptScan.ts
@@ -1,42 +1,28 @@
 import { useRef, useState } from 'react';
-import MlkitOcr from 'react-native-mlkit-ocr';
-import { parseReceiptOcr } from '../services/receiptService';
+import { parseReceiptImage } from '../services/receiptService';
 import type { ReceiptProduct } from '../types';
 
-export type ReceiptScanStep = 'idle' | 'ocr' | 'llm' | 'done' | 'error';
+export type ReceiptScanStep = 'idle' | 'processing' | 'done' | 'error';
 
 export function useReceiptScan() {
   const [step, setStep] = useState<ReceiptScanStep>('idle');
   const [items, setItems] = useState<ReceiptProduct[]>([]);
-  const [error, setError] = useState<'OCR_FAILED' | 'LLM_FAILED' | null>(null);
+  const [error, setError] = useState<'LLM_FAILED' | null>(null);
   const processingRef = useRef(false);
 
-  async function processPhoto(imageUri: string) {
+  async function processPhoto(imageBase64: string, mimeType = 'image/jpeg') {
     if (processingRef.current) return;
     processingRef.current = true;
     setError(null);
+    setStep('processing');
 
     try {
-      // Step 1 — on-device OCR via MLKit
-      setStep('ocr');
-      const blocks = await MlkitOcr.detectFromUri(imageUri);
-      const ocrText = blocks.map((b) => b.text).join('\n').trim();
-
-      if (!ocrText) {
-        setError('OCR_FAILED');
-        setStep('error');
-        return;
-      }
-
-      // Step 2 — Supabase Edge Function → Gemini Flash
-      setStep('llm');
-      const parsed = await parseReceiptOcr(ocrText);
+      const parsed = await parseReceiptImage(imageBase64, mimeType);
       setItems(parsed);
       setStep('done');
     } catch (err) {
       console.error('[useReceiptScan]', err);
-      const isOcrStep = step === 'ocr';
-      setError(isOcrStep ? 'OCR_FAILED' : 'LLM_FAILED');
+      setError('LLM_FAILED');
       setStep('error');
     } finally {
       processingRef.current = false;

--- a/features/scanning/services/receiptService.ts
+++ b/features/scanning/services/receiptService.ts
@@ -9,9 +9,12 @@ interface EdgeFunctionItem {
   duree_conservation_jours: number | null;
 }
 
-export async function parseReceiptOcr(ocrText: string): Promise<ReceiptProduct[]> {
+export async function parseReceiptImage(
+  imageBase64: string,
+  mimeType = 'image/jpeg',
+): Promise<ReceiptProduct[]> {
   const { data, error } = await supabase.functions.invoke('parse-receipt', {
-    body: { ocrText },
+    body: { imageBase64, mimeType },
   });
 
   if (error) throw error;

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -100,10 +100,8 @@
   "receiptScan": {
     "title": "Scanner un ticket",
     "hint": "Cadrez le ticket de caisse en entier",
-    "readingText": "Lecture du ticket…",
     "analyzing": "Analyse en cours…",
     "errorTitle": "Problème de lecture",
-    "errorOcr": "Impossible de lire le ticket. Vérifiez l'éclairage et réessayez.",
     "errorLlm": "L'analyse a échoué. Réessayez.",
     "errorEmpty": "Aucun produit alimentaire détecté. Réessayez."
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "react": "19.1.0",
         "react-i18next": "^16.5.4",
         "react-native": "0.81.5",
-        "react-native-mlkit-ocr": "^0.3.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-url-polyfill": "^3.0.0"
@@ -14451,16 +14450,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz",
       "integrity": "sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-mlkit-ocr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-mlkit-ocr/-/react-native-mlkit-ocr-0.3.0.tgz",
-      "integrity": "sha512-8oNJwNMGsUup41nWlKA01iW6xiNkCcXM3ANDsOKKijvsrd3eWNs7kL0Yhpt3Cq64zSyjoeqkdTdOCDiI6Pv6KA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react": "19.1.0",
     "react-i18next": "^16.5.4",
     "react-native": "0.81.5",
-    "react-native-mlkit-ocr": "^0.3.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-url-polyfill": "^3.0.0"

--- a/supabase/functions/parse-receipt/index.ts
+++ b/supabase/functions/parse-receipt/index.ts
@@ -19,15 +19,15 @@ interface GeminiResponse {
   }>;
 }
 
-const SYSTEM_PROMPT = `Tu es un assistant qui analyse le texte brut extrait par OCR d'un ticket de caisse français.
-Tu dois identifier les produits alimentaires et retourner un tableau JSON.
+const PROMPT = `Tu es un assistant qui analyse une photo de ticket de caisse français.
+Identifie tous les produits alimentaires visibles et retourne un tableau JSON.
 
-Pour chaque produit alimentaire identifié, retourne un objet avec ces champs :
-- nom : string — nom lisible du produit (corrige les abréviations OCR, ex: "YAO FRT 4X125" → "Yaourt aux fruits 4x125g")
+Pour chaque produit alimentaire, retourne un objet avec ces champs :
+- nom : string — nom lisible (corrige les abréviations, ex: "YAO FRT 4X125" → "Yaourt aux fruits 4x125g")
 - ingredient_tag : string | null — tag normalisé en minuscules sans accents (ex: "yaourt", "lait", "beurre"), null si incertain
 - quantite_estimee : number — quantité estimée (défaut 1)
 - unite : string — "unite", "kg", "g", "L", "mL", "lot"
-- duree_conservation_jours : number | null — estimation de durée de conservation en jours selon le type de produit, null si inconnu
+- duree_conservation_jours : number | null — estimation selon le type de produit, null si inconnu
 
 Règles :
 - Ignore les articles non alimentaires (produits ménagers, hygiène, etc.)
@@ -35,7 +35,6 @@ Règles :
 - Retourne UNIQUEMENT le tableau JSON, sans texte autour`;
 
 Deno.serve(async (req) => {
-  // CORS preflight
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       headers: {
@@ -69,16 +68,18 @@ Deno.serve(async (req) => {
       });
     }
 
-    // Parse request body
-    const { ocrText } = await req.json() as { ocrText?: string };
-    if (!ocrText?.trim()) {
-      return new Response(JSON.stringify({ error: 'Missing ocrText' }), {
+    // Parse request body — image sent as base64
+    const { imageBase64, mimeType = 'image/jpeg' } =
+      await req.json() as { imageBase64?: string; mimeType?: string };
+
+    if (!imageBase64) {
+      return new Response(JSON.stringify({ error: 'Missing imageBase64' }), {
         status: 400,
         headers: { 'Content-Type': 'application/json' },
       });
     }
 
-    // Call Gemini Flash
+    // Call Gemini Flash Vision
     const geminiKey = Deno.env.get('GEMINI_API_KEY');
     if (!geminiKey) throw new Error('GEMINI_API_KEY not configured');
 
@@ -86,8 +87,12 @@ Deno.serve(async (req) => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        system_instruction: { parts: [{ text: SYSTEM_PROMPT }] },
-        contents: [{ parts: [{ text: ocrText }] }],
+        contents: [{
+          parts: [
+            { inline_data: { mime_type: mimeType, data: imageBase64 } },
+            { text: PROMPT },
+          ],
+        }],
         generationConfig: {
           temperature: 0.1,
           responseMimeType: 'application/json',


### PR DESCRIPTION
## Problème

`react-native-mlkit-ocr@0.3.0` causait des conflits CocoaPods incompatibles avec RN 0.81 / Expo SDK 54. Build iOS échouait même avec `--clear-cache`.

## Fix

Suppression de MLKit. Le pipeline est simplifié : la photo est envoyée directement en base64 à la Supabase Edge Function, Gemini Flash 2.0 Vision lit ET parse le ticket en une seule étape.

```
avant : photo → MLKit OCR (natif) → texte → Gemini Flash → items
après : photo (base64) → Gemini Flash Vision → items
```

## Changements

- `parse-receipt` Edge Function : accepte `imageBase64` + `mimeType`, utilise `inline_data` Gemini Vision
- `receiptService.ts` : `parseReceiptImage(base64, mimeType)`
- `useReceiptScan` : une seule étape `processing`, plus d'import MLKit
- `scan-receipt.tsx` : `takePictureAsync({ base64: true, quality: 0.6 })`
- `package.json` : `react-native-mlkit-ocr` retiré
- i18n : clés `readingText` et `errorOcr` supprimées

Edge Function redeployée sur `torftqaixpywqomztkkm`.

## Test plan

- [ ] Build iOS sans erreur CocoaPods
- [ ] Photo ticket → produits parsés et affichés dans receipt-confirm
- [ ] Ticket illisible → message d'erreur + Réessayer