### PR TITLE
feat(stock): saisie manuelle de produit

### DIFF
--- a/app/(tabs)/add.tsx
+++ b/app/(tabs)/add.tsx
@@ -56,7 +56,7 @@ export default function AddScreen() {
           </View>
           <Ionicons name="chevron-forward" size={18} color="#9CA3AF" />
         </TouchableOpacity>
-        <TouchableOpacity style={styles.option}>
+        <TouchableOpacity style={styles.option} onPress={() => router.push('/add/manual-product')}>
           <View style={[styles.iconBox, { backgroundColor: '#E8F5E9' }]}>
             <Ionicons name="pencil-outline" size={26} color="#2E7D32" />
           </View>

--- a/app/add/_layout.tsx
+++ b/app/add/_layout.tsx
@@ -7,6 +7,7 @@ export default function AddLayout() {
       <Stack.Screen name="product-confirm" />
       <Stack.Screen name="scan-receipt" />
       <Stack.Screen name="receipt-confirm" />
+      <Stack.Screen name="manual-product" />
     </Stack>
   );
 }

--- a/app/add/manual-product.tsx
+++ b/app/add/manual-product.tsx
@@ -1,0 +1,571 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useTranslation } from 'react-i18next';
+import { supabase } from '@/lib/supabase';
+import { addToStock } from '@/features/stock/services/stockService';
+import type { Lieu, StockItemDraft, Unite } from '@/features/scanning/types';
+
+const LIEUX: { value: Lieu; label: string; icon: string }[] = [
+  { value: 'frigo', label: 'productConfirm.frigo', icon: 'snow-outline' },
+  { value: 'placard', label: 'productConfirm.placard', icon: 'cube-outline' },
+  { value: 'congelateur', label: 'productConfirm.congelateur', icon: 'thermometer-outline' },
+];
+
+const UNITES: Unite[] = ['pièce', 'g', 'kg', 'ml', 'L', 'boîte', 'sachet'];
+
+interface Ingredient {
+  tag: string;
+  categorie: string | null;
+}
+
+export default function ManualProductScreen() {
+  const { t } = useTranslation();
+
+  const [nom, setNom] = useState('');
+  const [quantite, setQuantite] = useState('1');
+  const [unite, setUnite] = useState<Unite>('pièce');
+  const [lieu, setLieu] = useState<Lieu>('frigo');
+  const [datePeremption, setDatePeremption] = useState<Date | null>(null);
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [pickerDate, setPickerDate] = useState(new Date());
+
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [tagModalVisible, setTagModalVisible] = useState(false);
+  const [ingredients, setIngredients] = useState<Ingredient[]>([]);
+  const [tagSearch, setTagSearch] = useState('');
+  const [loadingTags, setLoadingTags] = useState(false);
+
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    loadIngredients();
+  }, []);
+
+  async function loadIngredients() {
+    setLoadingTags(true);
+    try {
+      const { data } = await supabase
+        .from('ingredients')
+        .select('tag, categorie')
+        .order('tag', { ascending: true });
+      setIngredients(data ?? []);
+    } finally {
+      setLoadingTags(false);
+    }
+  }
+
+  const filteredIngredients = useCallback(() => {
+    if (!tagSearch.trim()) return ingredients;
+    const q = tagSearch.toLowerCase();
+    return ingredients.filter((i) => i.tag.toLowerCase().includes(q));
+  }, [ingredients, tagSearch]);
+
+  function formatDate(date: Date) {
+    return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' });
+  }
+
+  function handlePickerChange(_: DateTimePickerEvent, date?: Date) {
+    if (Platform.OS === 'android') {
+      setPickerVisible(false);
+      if (date) setDatePeremption(date);
+    } else {
+      if (date) setPickerDate(date);
+    }
+  }
+
+  function confirmIOSDate() {
+    setDatePeremption(pickerDate);
+    setPickerVisible(false);
+  }
+
+  async function handleSave() {
+    if (!nom.trim()) {
+      Alert.alert(t('productConfirm.errorNomRequired'));
+      return;
+    }
+
+    const qty = parseFloat(quantite.replace(',', '.'));
+    if (isNaN(qty) || qty <= 0) {
+      Alert.alert(t('productConfirm.errorQuantite'));
+      return;
+    }
+
+    const isoDate = datePeremption?.toISOString().split('T')[0] ?? null;
+
+    setSaving(true);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        Alert.alert(t('productConfirm.errorNotLoggedIn'));
+        return;
+      }
+
+      const { data: membre } = await supabase
+        .from('foyer_membres')
+        .select('foyer_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+
+      if (!membre) {
+        Alert.alert(t('productConfirm.errorNoFoyer'));
+        return;
+      }
+
+      const draft: StockItemDraft = {
+        scannedProduct: {
+          ean: '',
+          nom: nom.trim(),
+          ingredientTag: selectedTag ?? undefined,
+        },
+        quantite: qty,
+        unite,
+        datePeremption: isoDate,
+        lieu,
+      };
+
+      await addToStock(draft, membre.foyer_id as string, session.user.id);
+      router.replace('/(tabs)/stock');
+    } catch {
+      Alert.alert(t('common.error'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* Header */}
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+            <Ionicons name="arrow-back" size={24} color="#111111" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>{t('manualProduct.title')}</Text>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          {/* Nom */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('productConfirm.nom')}</Text>
+            <TextInput
+              style={styles.input}
+              value={nom}
+              onChangeText={setNom}
+              placeholder={t('productConfirm.nomPlaceholder')}
+              placeholderTextColor="#9CA3AF"
+              autoFocus
+            />
+          </View>
+
+          {/* Catégorie / ingredient_tag */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('manualProduct.categorie')}</Text>
+            <TouchableOpacity
+              style={[styles.tagBtn, selectedTag && styles.tagBtnSelected]}
+              onPress={() => setTagModalVisible(true)}
+            >
+              <Ionicons
+                name="pricetag-outline"
+                size={16}
+                color={selectedTag ? '#FF8400' : '#9CA3AF'}
+              />
+              <Text style={[styles.tagBtnText, selectedTag && styles.tagBtnTextSelected]}>
+                {selectedTag ?? t('manualProduct.categoriePlaceholder')}
+              </Text>
+              <Ionicons name="chevron-down" size={14} color={selectedTag ? '#FF8400' : '#9CA3AF'} />
+            </TouchableOpacity>
+          </View>
+
+          {/* Quantité + Unité */}
+          <View style={styles.row}>
+            <View style={[styles.field, styles.flex]}>
+              <Text style={styles.label}>{t('productConfirm.quantite')}</Text>
+              <TextInput
+                style={styles.input}
+                value={quantite}
+                onChangeText={setQuantite}
+                keyboardType="decimal-pad"
+                placeholder="1"
+                placeholderTextColor="#9CA3AF"
+                selectTextOnFocus
+              />
+            </View>
+            <View style={[styles.field, { width: 110 }]}>
+              <Text style={styles.label}>{t('productConfirm.unite')}</Text>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <View style={styles.uniteRow}>
+                  {UNITES.map((u) => (
+                    <TouchableOpacity
+                      key={u}
+                      style={[styles.uniteChip, unite === u && styles.uniteChipActive]}
+                      onPress={() => setUnite(u)}
+                    >
+                      <Text style={[styles.uniteChipText, unite === u && styles.uniteChipTextActive]}>
+                        {u}
+                      </Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </ScrollView>
+            </View>
+          </View>
+
+          {/* Date de péremption */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('productConfirm.datePeremption')}</Text>
+            <View style={styles.dateRow}>
+              <TouchableOpacity
+                style={[styles.dateBadge, datePeremption ? styles.dateBadgeSet : styles.dateBadgeEmpty]}
+                onPress={() => setPickerVisible(true)}
+              >
+                <Ionicons
+                  name="calendar-outline"
+                  size={16}
+                  color={datePeremption ? '#FF8400' : '#9CA3AF'}
+                />
+                <Text style={[styles.dateBadgeText, datePeremption ? styles.dateBadgeTextSet : styles.dateBadgeTextEmpty]}>
+                  {datePeremption ? formatDate(datePeremption) : t('productConfirm.pickDate')}
+                </Text>
+              </TouchableOpacity>
+              {datePeremption && (
+                <TouchableOpacity onPress={() => setDatePeremption(null)} style={styles.dateClear}>
+                  <Ionicons name="close-circle" size={20} color="#9CA3AF" />
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+
+          {/* Android date picker */}
+          {pickerVisible && Platform.OS === 'android' && (
+            <DateTimePicker
+              value={pickerDate}
+              mode="date"
+              display="default"
+              minimumDate={new Date()}
+              onChange={handlePickerChange}
+            />
+          )}
+
+          {/* Lieu */}
+          <View style={styles.field}>
+            <Text style={styles.label}>{t('productConfirm.lieu')}</Text>
+            <View style={styles.lieuRow}>
+              {LIEUX.map((l) => (
+                <TouchableOpacity
+                  key={l.value}
+                  style={[styles.lieuBtn, lieu === l.value && styles.lieuBtnActive]}
+                  onPress={() => setLieu(l.value)}
+                >
+                  <Ionicons
+                    name={l.icon as any}
+                    size={20}
+                    color={lieu === l.value ? '#FF8400' : '#6B7280'}
+                  />
+                  <Text style={[styles.lieuBtnText, lieu === l.value && styles.lieuBtnTextActive]}>
+                    {t(l.label)}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Save button */}
+          <TouchableOpacity
+            style={[styles.saveBtn, saving && styles.saveBtnDisabled]}
+            onPress={handleSave}
+            disabled={saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#FFFFFF" />
+            ) : (
+              <Text style={styles.saveBtnText}>{t('productConfirm.addToStock')}</Text>
+            )}
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      {/* iOS date picker bottom sheet */}
+      {Platform.OS === 'ios' && (
+        <Modal visible={pickerVisible} transparent animationType="slide">
+          <View style={styles.pickerOverlay}>
+            <View style={styles.pickerSheet}>
+              <View style={styles.pickerHeader}>
+                <TouchableOpacity onPress={() => setPickerVisible(false)}>
+                  <Text style={styles.pickerCancel}>{t('common.cancel')}</Text>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={confirmIOSDate}>
+                  <Text style={styles.pickerConfirm}>{t('common.confirm')}</Text>
+                </TouchableOpacity>
+              </View>
+              <DateTimePicker
+                value={pickerDate}
+                mode="date"
+                display="spinner"
+                minimumDate={new Date()}
+                onChange={handlePickerChange}
+                locale="fr-FR"
+              />
+            </View>
+          </View>
+        </Modal>
+      )}
+
+      {/* Ingredient tag picker modal */}
+      <Modal visible={tagModalVisible} animationType="slide" onRequestClose={() => setTagModalVisible(false)}>
+        <SafeAreaView style={styles.modalSafe}>
+          <View style={styles.modalHeader}>
+            <Text style={styles.modalTitle}>{t('manualProduct.categorie')}</Text>
+            <TouchableOpacity onPress={() => setTagModalVisible(false)} style={styles.modalClose}>
+              <Ionicons name="close" size={24} color="#111111" />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.searchBar}>
+            <Ionicons name="search-outline" size={16} color="#9CA3AF" />
+            <TextInput
+              style={styles.searchInput}
+              value={tagSearch}
+              onChangeText={setTagSearch}
+              placeholder={t('common.search')}
+              placeholderTextColor="#9CA3AF"
+              autoFocus
+              clearButtonMode="while-editing"
+            />
+          </View>
+
+          {/* Clear selection */}
+          {selectedTag && (
+            <TouchableOpacity
+              style={styles.clearTagBtn}
+              onPress={() => { setSelectedTag(null); setTagModalVisible(false); }}
+            >
+              <Ionicons name="close-circle-outline" size={16} color="#EF4444" />
+              <Text style={styles.clearTagText}>{t('manualProduct.clearCategorie')}</Text>
+            </TouchableOpacity>
+          )}
+
+          {loadingTags ? (
+            <View style={styles.centered}>
+              <ActivityIndicator color="#FF8400" />
+            </View>
+          ) : filteredIngredients().length === 0 ? (
+            <View style={styles.centered}>
+              <Text style={styles.emptyText}>{t('manualProduct.noResults')}</Text>
+            </View>
+          ) : (
+            <FlatList
+              data={filteredIngredients()}
+              keyExtractor={(item) => item.tag}
+              keyboardShouldPersistTaps="handled"
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  style={[styles.tagItem, selectedTag === item.tag && styles.tagItemSelected]}
+                  onPress={() => { setSelectedTag(item.tag); setTagModalVisible(false); setTagSearch(''); }}
+                >
+                  <Text style={[styles.tagItemText, selectedTag === item.tag && styles.tagItemTextSelected]}>
+                    {item.tag}
+                  </Text>
+                  {item.categorie && (
+                    <Text style={styles.tagItemCategorie}>{item.categorie}</Text>
+                  )}
+                  {selectedTag === item.tag && (
+                    <Ionicons name="checkmark" size={18} color="#FF8400" />
+                  )}
+                </TouchableOpacity>
+              )}
+              ItemSeparatorComponent={() => <View style={styles.separator} />}
+              contentContainerStyle={{ paddingBottom: 24 }}
+            />
+          )}
+        </SafeAreaView>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: '#F2F3F0' },
+  flex: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    backgroundColor: '#F2F3F0',
+  },
+  backBtn: { padding: 4 },
+  headerTitle: { fontSize: 18, fontWeight: '600', color: '#111111' },
+  content: { paddingHorizontal: 20, paddingBottom: 40, gap: 16 },
+
+  field: { gap: 6 },
+  label: { fontSize: 13, fontWeight: '600', color: '#374151', textTransform: 'uppercase', letterSpacing: 0.5 },
+  input: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 15,
+    color: '#111111',
+  },
+
+  // Tag selector
+  tagBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderWidth: 1.5,
+    borderStyle: 'dashed',
+    borderColor: '#D1D5DB',
+  },
+  tagBtnSelected: { borderStyle: 'solid', borderColor: '#FF8400', backgroundColor: '#FFF3E0' },
+  tagBtnText: { flex: 1, fontSize: 15, color: '#9CA3AF' },
+  tagBtnTextSelected: { color: '#FF8400', fontWeight: '600' },
+
+  // Row
+  row: { flexDirection: 'row', gap: 12 },
+  uniteRow: { flexDirection: 'row', gap: 6 },
+  uniteChip: {
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  uniteChipActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
+  uniteChipText: { fontSize: 13, color: '#6B7280' },
+  uniteChipTextActive: { color: '#FF8400', fontWeight: '600' },
+
+  // Date picker
+  dateRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  dateBadge: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderWidth: 1.5,
+    borderStyle: 'dashed',
+  },
+  dateBadgeEmpty: { backgroundColor: '#FFFFFF', borderColor: '#D1D5DB' },
+  dateBadgeSet: { backgroundColor: '#FFF3E0', borderColor: '#FF8400', borderStyle: 'solid' },
+  dateBadgeText: { fontSize: 15 },
+  dateBadgeTextEmpty: { color: '#9CA3AF' },
+  dateBadgeTextSet: { color: '#FF8400', fontWeight: '600' },
+  dateClear: { padding: 4 },
+
+  // Lieu
+  lieuRow: { flexDirection: 'row', gap: 10 },
+  lieuBtn: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 6,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+  },
+  lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
+  lieuBtnText: { fontSize: 12, color: '#6B7280', textAlign: 'center' },
+  lieuBtnTextActive: { color: '#FF8400', fontWeight: '600' },
+
+  // Save
+  saveBtn: {
+    backgroundColor: '#FF8400',
+    borderRadius: 14,
+    padding: 16,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  saveBtnDisabled: { opacity: 0.6 },
+  saveBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+
+  // iOS date picker sheet
+  pickerOverlay: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.3)' },
+  pickerSheet: { backgroundColor: '#FFFFFF', borderTopLeftRadius: 20, borderTopRightRadius: 20, paddingBottom: 34 },
+  pickerHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  pickerCancel: { fontSize: 16, color: '#6B7280' },
+  pickerConfirm: { fontSize: 16, fontWeight: '600', color: '#FF8400' },
+
+  // Tag modal
+  modalSafe: { flex: 1, backgroundColor: '#FFFFFF' },
+  modalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  modalTitle: { fontSize: 17, fontWeight: '600', color: '#111111' },
+  modalClose: { padding: 4 },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    margin: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: '#F3F4F6',
+    borderRadius: 10,
+  },
+  searchInput: { flex: 1, fontSize: 15, color: '#111111' },
+  clearTagBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+  },
+  clearTagText: { fontSize: 14, color: '#EF4444' },
+  tagItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+  },
+  tagItemSelected: { backgroundColor: '#FFF3E0' },
+  tagItemText: { flex: 1, fontSize: 15, color: '#111111', textTransform: 'capitalize' },
+  tagItemTextSelected: { color: '#FF8400', fontWeight: '600' },
+  tagItemCategorie: { fontSize: 12, color: '#9CA3AF', marginRight: 8 },
+  separator: { height: 1, backgroundColor: '#F3F4F6', marginLeft: 20 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingTop: 60 },
+  emptyText: { fontSize: 14, color: '#9CA3AF' },
+});

--- a/app/add/receipt-confirm.tsx
+++ b/app/add/receipt-confirm.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Alert,
   KeyboardAvoidingView,
+  Modal,
   Platform,
   ScrollView,
   StyleSheet,
@@ -14,6 +15,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router, useLocalSearchParams } from 'expo-router';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import DateTimePicker, { type DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import { useTranslation } from 'react-i18next';
 import { supabase } from '@/lib/supabase';
 import { addReceiptItemsToStock } from '@/features/stock/services/stockService';
@@ -27,20 +29,13 @@ const LIEUX: { value: Lieu; icon: string }[] = [
 
 const UNITS = ['unite', 'g', 'kg', 'L', 'mL', 'lot'];
 
-function dureeToDateStr(jours: number | undefined): string {
-  if (!jours) return '';
-  const d = new Date(Date.now() + jours * 86_400_000);
-  const day = String(d.getDate()).padStart(2, '0');
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  return `${day}/${month}/${d.getFullYear()}`;
+function computeDefaultDate(jours: number | undefined): Date | null {
+  if (!jours) return null;
+  return new Date(Date.now() + jours * 86_400_000);
 }
 
-function dateStrToISO(str: string): string | null {
-  const parts = str.trim().split('/');
-  if (parts.length !== 3) return null;
-  const [day, month, year] = parts;
-  if (year.length !== 4) return null;
-  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('fr-FR', { day: 'numeric', month: 'short', year: 'numeric' });
 }
 
 interface EditableItem {
@@ -50,7 +45,7 @@ interface EditableItem {
   quantiteStr: string;
   unite: string;
   lieu: Lieu;
-  datePeremption: string; // JJ/MM/AAAA, vide si inconnu
+  datePeremption: Date | null;
   checked: boolean;
   ingredientTag?: string;
   dureeConservationJours?: number;
@@ -69,13 +64,18 @@ export default function ReceiptConfirmScreen() {
       quantiteStr: String(item.quantiteEstimee ?? 1),
       unite: item.unite ?? 'unite',
       lieu: 'frigo',
-      datePeremption: dureeToDateStr(item.dureeConservationJours),
+      datePeremption: computeDefaultDate(item.dureeConservationJours),
       checked: true,
       ingredientTag: item.ingredientTag,
       dureeConservationJours: item.dureeConservationJours,
     })),
   );
   const [saving, setSaving] = useState(false);
+
+  // Date picker state
+  const [pickerVisible, setPickerVisible] = useState(false);
+  const [pickerItemId, setPickerItemId] = useState<string | null>(null);
+  const [pickerDate, setPickerDate] = useState(new Date());
 
   const checkedItems = editableItems.filter((item) => item.checked);
 
@@ -120,16 +120,50 @@ export default function ReceiptConfirmScreen() {
     );
   }
 
-  function updateDate(id: string, datePeremption: string) {
-    setEditableItems((prev) =>
-      prev.map((item) => (item.id === id ? { ...item, datePeremption } : item)),
-    );
-  }
-
   function updateLieu(id: string, lieu: Lieu) {
     setEditableItems((prev) =>
       prev.map((item) => (item.id === id ? { ...item, lieu } : item)),
     );
+  }
+
+  function clearDate(id: string) {
+    setEditableItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, datePeremption: null } : item)),
+    );
+  }
+
+  function openDatePicker(id: string, current: Date | null) {
+    setPickerItemId(id);
+    setPickerDate(current ?? new Date());
+    setPickerVisible(true);
+  }
+
+  function handlePickerChange(_: DateTimePickerEvent, date?: Date) {
+    if (Platform.OS === 'android') {
+      setPickerVisible(false);
+      if (date && pickerItemId) {
+        setEditableItems((prev) =>
+          prev.map((item) =>
+            item.id === pickerItemId ? { ...item, datePeremption: date } : item,
+          ),
+        );
+      }
+      setPickerItemId(null);
+    } else {
+      if (date) setPickerDate(date);
+    }
+  }
+
+  function confirmIOSDate() {
+    if (pickerItemId) {
+      setEditableItems((prev) =>
+        prev.map((item) =>
+          item.id === pickerItemId ? { ...item, datePeremption: pickerDate } : item,
+        ),
+      );
+    }
+    setPickerVisible(false);
+    setPickerItemId(null);
   }
 
   function pickUnit(id: string, currentUnite: string) {
@@ -176,7 +210,7 @@ export default function ReceiptConfirmScreen() {
           quantite: item.quantite,
           unite: item.unite,
           dureeConservationJours: item.dureeConservationJours,
-          datePeremption: dateStrToISO(item.datePeremption),
+          datePeremption: item.datePeremption?.toISOString().split('T')[0] ?? null,
           lieu: item.lieu,
         }));
 
@@ -247,11 +281,9 @@ export default function ReceiptConfirmScreen() {
                     />
                   </View>
 
-                  {/* Row 2: qty input + unit picker + lieu (checked only) */}
+                  {/* Row 2: qty + unit + lieu (checked only) */}
                   {item.checked && (
                     <View style={styles.row2}>
-
-                      {/* Quantity — direct text input, tap to type new value */}
                       <TextInput
                         style={styles.qtyInput}
                         value={item.quantiteStr}
@@ -260,8 +292,6 @@ export default function ReceiptConfirmScreen() {
                         keyboardType="numeric"
                         selectTextOnFocus
                       />
-
-                      {/* Unit picker */}
                       <TouchableOpacity
                         style={styles.unitBtn}
                         onPress={() => pickUnit(item.id, item.unite)}
@@ -273,7 +303,6 @@ export default function ReceiptConfirmScreen() {
 
                       <View style={styles.rowSpacer} />
 
-                      {/* Per-item lieu */}
                       {LIEUX.map((l) => (
                         <TouchableOpacity
                           key={l.value}
@@ -291,18 +320,41 @@ export default function ReceiptConfirmScreen() {
                     </View>
                   )}
 
-                  {/* Row 3: date de péremption (checked only) */}
+                  {/* Row 3: expiry date (checked only) */}
                   {item.checked && (
                     <View style={styles.row3}>
-                      <Ionicons name="calendar-outline" size={14} color="#9CA3AF" />
-                      <TextInput
-                        style={styles.dateInput}
-                        value={item.datePeremption}
-                        onChangeText={(text) => updateDate(item.id, text)}
-                        placeholder={t('receiptConfirm.datePlaceholder')}
-                        placeholderTextColor="#9CA3AF"
-                        keyboardType="numeric"
-                      />
+                      <TouchableOpacity
+                        style={[
+                          styles.dateBadge,
+                          item.datePeremption ? styles.dateBadgeFilled : styles.dateBadgeEmpty,
+                        ]}
+                        onPress={() => openDatePicker(item.id, item.datePeremption)}
+                      >
+                        <Ionicons
+                          name="calendar-outline"
+                          size={13}
+                          color={item.datePeremption ? '#FF8400' : '#9CA3AF'}
+                        />
+                        <Text
+                          style={[
+                            styles.dateBadgeText,
+                            item.datePeremption && styles.dateBadgeTextFilled,
+                          ]}
+                        >
+                          {item.datePeremption
+                            ? formatDate(item.datePeremption)
+                            : t('receiptConfirm.addDate')}
+                        </Text>
+                      </TouchableOpacity>
+
+                      {item.datePeremption && (
+                        <TouchableOpacity
+                          onPress={() => clearDate(item.id)}
+                          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        >
+                          <Ionicons name="close-circle" size={16} color="#D1D5DB" />
+                        </TouchableOpacity>
+                      )}
                     </View>
                   )}
                 </View>
@@ -311,7 +363,7 @@ export default function ReceiptConfirmScreen() {
           )}
         </ScrollView>
 
-        {/* Sticky footer: CTA only */}
+        {/* Sticky footer: CTA */}
         <SafeAreaView edges={['bottom']} style={styles.footer}>
           <TouchableOpacity
             style={[styles.saveBtn, (saving || checkedItems.length === 0) && styles.saveBtnDisabled]}
@@ -328,6 +380,50 @@ export default function ReceiptConfirmScreen() {
           </TouchableOpacity>
         </SafeAreaView>
       </KeyboardAvoidingView>
+
+      {/* Android: picker renders directly (dialog auto-dismisses) */}
+      {pickerVisible && Platform.OS === 'android' && (
+        <DateTimePicker
+          value={pickerDate}
+          mode="date"
+          display="default"
+          onChange={handlePickerChange}
+        />
+      )}
+
+      {/* iOS: picker in a bottom sheet */}
+      {Platform.OS === 'ios' && (
+        <Modal
+          visible={pickerVisible}
+          transparent
+          animationType="slide"
+          onRequestClose={() => setPickerVisible(false)}
+        >
+          <TouchableOpacity
+            style={styles.modalOverlay}
+            activeOpacity={1}
+            onPress={() => setPickerVisible(false)}
+          />
+          <View style={styles.pickerSheet}>
+            <View style={styles.pickerHeader}>
+              <TouchableOpacity onPress={() => setPickerVisible(false)}>
+                <Text style={styles.pickerCancel}>{t('common.cancel')}</Text>
+              </TouchableOpacity>
+              <Text style={styles.pickerTitle}>{t('receiptConfirm.addDate')}</Text>
+              <TouchableOpacity onPress={confirmIOSDate}>
+                <Text style={styles.pickerConfirm}>{t('common.confirm')}</Text>
+              </TouchableOpacity>
+            </View>
+            <DateTimePicker
+              value={pickerDate}
+              mode="date"
+              display="spinner"
+              onChange={handlePickerChange}
+              locale="fr-FR"
+            />
+          </View>
+        </Modal>
+      )}
     </SafeAreaView>
   );
 }
@@ -373,28 +469,16 @@ const styles = StyleSheet.create({
   row2: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingLeft: 36, // aligns with name field (checkbox 26px + gap 10px)
+    paddingLeft: 36,
     gap: 6,
   },
-  rowSpacer: { flex: 1 },
-
   row3: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingLeft: 36,
     gap: 6,
   },
-  dateInput: {
-    flex: 1,
-    fontSize: 13,
-    color: '#111111',
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-    borderRadius: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    backgroundColor: '#F9FAFB',
-  },
+  rowSpacer: { flex: 1 },
 
   checkbox: { padding: 2 },
 
@@ -446,6 +530,29 @@ const styles = StyleSheet.create({
   },
   lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
 
+  dateBadge: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  dateBadgeEmpty: {
+    borderColor: '#D1D5DB',
+    borderStyle: 'dashed',
+    backgroundColor: 'transparent',
+  },
+  dateBadgeFilled: {
+    borderColor: '#FF8400',
+    borderStyle: 'solid',
+    backgroundColor: '#FFF3E0',
+  },
+  dateBadgeText: { fontSize: 12, color: '#9CA3AF' },
+  dateBadgeTextFilled: { color: '#FF8400', fontWeight: '500' },
+
   footer: {
     backgroundColor: '#FFFFFF',
     paddingHorizontal: 16,
@@ -467,4 +574,28 @@ const styles = StyleSheet.create({
   },
   saveBtnDisabled: { opacity: 0.45 },
   saveBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+
+  // Date picker modal (iOS)
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  pickerSheet: {
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingBottom: 32,
+  },
+  pickerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: '#F3F4F6',
+  },
+  pickerTitle: { fontSize: 15, fontWeight: '600', color: '#111111' },
+  pickerCancel: { fontSize: 15, color: '#6B7280' },
+  pickerConfirm: { fontSize: 15, color: '#FF8400', fontWeight: '600' },
 });

--- a/app/add/receipt-confirm.tsx
+++ b/app/add/receipt-confirm.tsx
@@ -28,8 +28,9 @@ const LIEUX: { value: Lieu; label: string; icon: string }[] = [
 interface EditableItem {
   id: string;
   nom: string;
-  quantite: string;
+  quantite: number;
   unite: string;
+  checked: boolean;
   ingredientTag?: string;
   dureeConservationJours?: number;
 }
@@ -37,15 +38,15 @@ interface EditableItem {
 export default function ReceiptConfirmScreen() {
   const { t } = useTranslation();
   const params = useLocalSearchParams<{ items: string }>();
-
   const initial: ReceiptProduct[] = JSON.parse(params.items ?? '[]');
 
   const [editableItems, setEditableItems] = useState<EditableItem[]>(
     initial.map((item, i) => ({
       id: String(i),
       nom: item.nom,
-      quantite: String(item.quantiteEstimee ?? 1),
+      quantite: item.quantiteEstimee ?? 1,
       unite: item.unite ?? 'unite',
+      checked: true,
       ingredientTag: item.ingredientTag,
       dureeConservationJours: item.dureeConservationJours,
     })),
@@ -53,26 +54,37 @@ export default function ReceiptConfirmScreen() {
   const [lieu, setLieu] = useState<Lieu>('frigo');
   const [saving, setSaving] = useState(false);
 
-  function updateItem(id: string, patch: Partial<EditableItem>) {
-    setEditableItems((prev) => prev.map((item) => (item.id === id ? { ...item, ...patch } : item)));
+  const checkedItems = editableItems.filter((item) => item.checked);
+
+  function toggleItem(id: string) {
+    setEditableItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, checked: !item.checked } : item)),
+    );
   }
 
-  function removeItem(id: string) {
-    setEditableItems((prev) => prev.filter((item) => item.id !== id));
+  function updateName(id: string, nom: string) {
+    setEditableItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, nom } : item)),
+    );
+  }
+
+  function updateQty(id: string, delta: number) {
+    setEditableItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, quantite: Math.max(1, item.quantite + delta) } : item,
+      ),
+    );
   }
 
   async function handleSaveAll() {
-    const validItems = editableItems.filter((item) => item.nom.trim());
-    if (validItems.length === 0) {
+    if (checkedItems.length === 0) {
       Alert.alert(t('receiptConfirm.errorNoItems'));
       return;
     }
 
     setSaving(true);
     try {
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
+      const { data: { session } } = await supabase.auth.getSession();
       if (!session) return;
 
       const { data: membre } = await supabase
@@ -86,14 +98,16 @@ export default function ReceiptConfirmScreen() {
         return;
       }
 
-      const drafts: ReceiptItemDraft[] = validItems.map((item) => ({
-        nom: item.nom.trim(),
-        ingredientTag: item.ingredientTag,
-        quantite: parseFloat(item.quantite.replace(',', '.')) || 1,
-        unite: item.unite,
-        dureeConservationJours: item.dureeConservationJours,
-        lieu,
-      }));
+      const drafts: ReceiptItemDraft[] = checkedItems
+        .filter((item) => item.nom.trim())
+        .map((item) => ({
+          nom: item.nom.trim(),
+          ingredientTag: item.ingredientTag,
+          quantite: item.quantite,
+          unite: item.unite,
+          dureeConservationJours: item.dureeConservationJours,
+          lieu,
+        }));
 
       await addReceiptItemsToStock(drafts, membre.foyer_id as string, session.user.id);
       router.replace('/(tabs)/stock');
@@ -105,29 +119,96 @@ export default function ReceiptConfirmScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.safeArea}>
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
         {/* Header */}
         <View style={styles.header}>
-          <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+          <TouchableOpacity
+            onPress={() => router.back()}
+            style={styles.backBtn}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
             <Ionicons name="arrow-back" size={24} color="#111111" />
           </TouchableOpacity>
-          <View style={styles.flex}>
-            <Text style={styles.headerTitle}>{t('receiptConfirm.title')}</Text>
-            <Text style={styles.headerSubtitle}>
-              {t('receiptConfirm.itemCount', { count: editableItems.length })}
-            </Text>
+          <Text style={styles.headerTitle}>{t('receiptConfirm.title')}</Text>
+          <View style={styles.countBadge}>
+            <Text style={styles.countBadgeText}>{checkedItems.length}/{editableItems.length}</Text>
           </View>
         </View>
 
-        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
-          {/* Lieu global */}
-          <View style={styles.section}>
-            <Text style={styles.sectionLabel}>{t('receiptConfirm.lieu')}</Text>
-            <View style={styles.lieuRow}>
+        {/* Items list */}
+        <ScrollView
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {editableItems.length === 0 ? (
+            <View style={styles.emptyState}>
+              <Ionicons name="receipt-outline" size={40} color="#D1D5DB" />
+              <Text style={styles.emptyText}>{t('receiptConfirm.empty')}</Text>
+            </View>
+          ) : (
+            <View style={styles.itemsList}>
+              {editableItems.map((item) => (
+                <View key={item.id} style={[styles.itemCard, !item.checked && styles.itemCardUnchecked]}>
+                  <TouchableOpacity
+                    onPress={() => toggleItem(item.id)}
+                    style={styles.checkbox}
+                    hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+                  >
+                    <Ionicons
+                      name={item.checked ? 'checkmark-circle' : 'ellipse-outline'}
+                      size={26}
+                      color={item.checked ? '#FF8400' : '#D1D5DB'}
+                    />
+                  </TouchableOpacity>
+
+                  <TextInput
+                    style={[styles.itemName, !item.checked && styles.itemNameUnchecked]}
+                    value={item.nom}
+                    onChangeText={(text) => updateName(item.id, text)}
+                    editable={item.checked}
+                    placeholderTextColor="#9CA3AF"
+                  />
+
+                  {item.checked && (
+                    <View style={styles.stepper}>
+                      <TouchableOpacity
+                        onPress={() => updateQty(item.id, -1)}
+                        style={styles.stepperBtn}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 4 }}
+                      >
+                        <Ionicons name="remove" size={16} color="#6B7280" />
+                      </TouchableOpacity>
+                      <Text style={styles.stepperValue}>
+                        {item.quantite}
+                        {item.unite !== 'unite' && (
+                          <Text style={styles.stepperUnit}> {item.unite}</Text>
+                        )}
+                      </Text>
+                      <TouchableOpacity
+                        onPress={() => updateQty(item.id, 1)}
+                        style={styles.stepperBtn}
+                        hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
+                      >
+                        <Ionicons name="add" size={16} color="#6B7280" />
+                      </TouchableOpacity>
+                    </View>
+                  )}
+                </View>
+              ))}
+            </View>
+          )}
+        </ScrollView>
+
+        {/* Sticky footer: lieu + CTA */}
+        <SafeAreaView edges={['bottom']} style={styles.footer}>
+          <View style={styles.lieuRow}>
+            <Text style={styles.lieuLabel}>{t('receiptConfirm.lieu')}</Text>
+            <View style={styles.lieuBtns}>
               {LIEUX.map((l) => (
                 <TouchableOpacity
                   key={l.value}
@@ -136,8 +217,8 @@ export default function ReceiptConfirmScreen() {
                 >
                   <Ionicons
                     name={l.icon as never}
-                    size={18}
-                    color={lieu === l.value ? '#FF8400' : '#6B7280'}
+                    size={15}
+                    color={lieu === l.value ? '#FF8400' : '#9CA3AF'}
                   />
                   <Text style={[styles.lieuBtnText, lieu === l.value && styles.lieuBtnTextActive]}>
                     {t(l.label)}
@@ -147,69 +228,20 @@ export default function ReceiptConfirmScreen() {
             </View>
           </View>
 
-          {/* Items list */}
-          {editableItems.length === 0 ? (
-            <View style={styles.emptyState}>
-              <Ionicons name="receipt-outline" size={40} color="#D1D5DB" />
-              <Text style={styles.emptyText}>{t('receiptConfirm.empty')}</Text>
-            </View>
-          ) : (
-            <View style={styles.itemsList}>
-              {editableItems.map((item) => (
-                <View key={item.id} style={styles.itemCard}>
-                  <View style={styles.itemRow}>
-                    <TextInput
-                      style={[styles.input, styles.inputNom]}
-                      value={item.nom}
-                      onChangeText={(text) => updateItem(item.id, { nom: text })}
-                      placeholder={t('productConfirm.nomPlaceholder')}
-                      placeholderTextColor="#9CA3AF"
-                    />
-                    <TouchableOpacity
-                      onPress={() => removeItem(item.id)}
-                      style={styles.removeBtn}
-                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                    >
-                      <Ionicons name="close-circle" size={20} color="#EF4444" />
-                    </TouchableOpacity>
-                  </View>
-                  <View style={styles.itemRow}>
-                    <TextInput
-                      style={[styles.input, styles.inputQty]}
-                      value={item.quantite}
-                      onChangeText={(text) => updateItem(item.id, { quantite: text })}
-                      keyboardType="decimal-pad"
-                    />
-                    <TextInput
-                      style={[styles.input, styles.inputUnite]}
-                      value={item.unite}
-                      onChangeText={(text) => updateItem(item.id, { unite: text })}
-                      autoCapitalize="none"
-                    />
-                  </View>
-                </View>
-              ))}
-            </View>
-          )}
-
-          {/* Save button */}
           <TouchableOpacity
-            style={[
-              styles.saveBtn,
-              (saving || editableItems.length === 0) && styles.saveBtnDisabled,
-            ]}
+            style={[styles.saveBtn, (saving || checkedItems.length === 0) && styles.saveBtnDisabled]}
             onPress={handleSaveAll}
-            disabled={saving || editableItems.length === 0}
+            disabled={saving || checkedItems.length === 0}
           >
             {saving ? (
               <ActivityIndicator color="#FFFFFF" />
             ) : (
               <Text style={styles.saveBtnText}>
-                {t('receiptConfirm.addAll', { count: editableItems.length })}
+                {t('receiptConfirm.addAll', { count: checkedItems.length })}
               </Text>
             )}
           </TouchableOpacity>
-        </ScrollView>
+        </SafeAreaView>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
@@ -218,6 +250,7 @@ export default function ReceiptConfirmScreen() {
 const styles = StyleSheet.create({
   safeArea: { flex: 1, backgroundColor: '#F2F3F0' },
   flex: { flex: 1 },
+
   header: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -227,68 +260,109 @@ const styles = StyleSheet.create({
     backgroundColor: '#F2F3F0',
   },
   backBtn: { padding: 4 },
-  headerTitle: { fontSize: 18, fontWeight: '600', color: '#111111' },
-  headerSubtitle: { fontSize: 13, color: '#6B7280', marginTop: 1 },
-  content: { paddingHorizontal: 20, paddingBottom: 40, gap: 20 },
-  section: { gap: 8 },
-  sectionLabel: {
-    fontSize: 13,
-    fontWeight: '600',
-    color: '#374151',
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
+  headerTitle: { flex: 1, fontSize: 18, fontWeight: '600', color: '#111111' },
+  countBadge: {
+    backgroundColor: '#FF8400',
+    borderRadius: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
   },
-  lieuRow: { flexDirection: 'row', gap: 10 },
+  countBadgeText: { fontSize: 13, fontWeight: '700', color: '#FFFFFF' },
+
+  content: { paddingHorizontal: 16, paddingTop: 4, paddingBottom: 16 },
+
+  emptyState: { alignItems: 'center', gap: 12, paddingVertical: 60 },
+  emptyText: { fontSize: 15, color: '#9CA3AF', textAlign: 'center' },
+
+  itemsList: { gap: 8 },
+  itemCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    gap: 10,
+    minHeight: 56,
+  },
+  itemCardUnchecked: { backgroundColor: '#F9FAFB', opacity: 0.55 },
+
+  checkbox: { padding: 2 },
+
+  itemName: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '500',
+    color: '#111111',
+    paddingVertical: 4,
+  },
+  itemNameUnchecked: { color: '#9CA3AF', textDecorationLine: 'line-through' },
+
+  stepper: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+    borderRadius: 10,
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+    gap: 6,
+  },
+  stepperBtn: {
+    width: 28,
+    height: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+  },
+  stepperValue: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111111',
+    minWidth: 28,
+    textAlign: 'center',
+  },
+  stepperUnit: { fontSize: 12, fontWeight: '400', color: '#6B7280' },
+
+  footer: {
+    backgroundColor: '#FFFFFF',
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 8,
+    gap: 12,
+    borderTopWidth: 1,
+    borderTopColor: '#F3F4F6',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    elevation: 8,
+  },
+  lieuRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  lieuLabel: { fontSize: 13, color: '#6B7280', fontWeight: '500' },
+  lieuBtns: { flex: 1, flexDirection: 'row', gap: 8 },
   lieuBtn: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 6,
-    backgroundColor: '#FFFFFF',
+    gap: 5,
+    paddingVertical: 8,
     borderRadius: 10,
-    padding: 10,
     borderWidth: 1,
     borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
   },
   lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
-  lieuBtnText: { fontSize: 12, color: '#6B7280' },
+  lieuBtnText: { fontSize: 12, color: '#9CA3AF', fontWeight: '500' },
   lieuBtnTextActive: { color: '#FF8400', fontWeight: '600' },
-  itemsList: { gap: 10 },
-  itemCard: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 12,
-    padding: 12,
-    gap: 8,
-  },
-  itemRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  input: {
-    backgroundColor: '#F9FAFB',
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 9,
-    fontSize: 14,
-    color: '#111111',
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-  },
-  inputNom: { flex: 1 },
-  inputQty: { width: 64 },
-  inputUnite: { width: 80 },
-  removeBtn: { padding: 2 },
-  emptyState: {
-    alignItems: 'center',
-    gap: 12,
-    paddingVertical: 40,
-  },
-  emptyText: { fontSize: 15, color: '#9CA3AF', textAlign: 'center' },
+
   saveBtn: {
     backgroundColor: '#FF8400',
     borderRadius: 14,
-    padding: 16,
+    paddingVertical: 16,
     alignItems: 'center',
-    marginTop: 4,
   },
-  saveBtnDisabled: { opacity: 0.5 },
+  saveBtnDisabled: { opacity: 0.45 },
   saveBtnText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
 });

--- a/app/add/receipt-confirm.tsx
+++ b/app/add/receipt-confirm.tsx
@@ -27,6 +27,22 @@ const LIEUX: { value: Lieu; icon: string }[] = [
 
 const UNITS = ['unite', 'g', 'kg', 'L', 'mL', 'lot'];
 
+function dureeToDateStr(jours: number | undefined): string {
+  if (!jours) return '';
+  const d = new Date(Date.now() + jours * 86_400_000);
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  return `${day}/${month}/${d.getFullYear()}`;
+}
+
+function dateStrToISO(str: string): string | null {
+  const parts = str.trim().split('/');
+  if (parts.length !== 3) return null;
+  const [day, month, year] = parts;
+  if (year.length !== 4) return null;
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+}
+
 interface EditableItem {
   id: string;
   nom: string;
@@ -34,6 +50,7 @@ interface EditableItem {
   quantiteStr: string;
   unite: string;
   lieu: Lieu;
+  datePeremption: string; // JJ/MM/AAAA, vide si inconnu
   checked: boolean;
   ingredientTag?: string;
   dureeConservationJours?: number;
@@ -52,6 +69,7 @@ export default function ReceiptConfirmScreen() {
       quantiteStr: String(item.quantiteEstimee ?? 1),
       unite: item.unite ?? 'unite',
       lieu: 'frigo',
+      datePeremption: dureeToDateStr(item.dureeConservationJours),
       checked: true,
       ingredientTag: item.ingredientTag,
       dureeConservationJours: item.dureeConservationJours,
@@ -99,6 +117,12 @@ export default function ReceiptConfirmScreen() {
   function updateUnite(id: string, unite: string) {
     setEditableItems((prev) =>
       prev.map((item) => (item.id === id ? { ...item, unite } : item)),
+    );
+  }
+
+  function updateDate(id: string, datePeremption: string) {
+    setEditableItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, datePeremption } : item)),
     );
   }
 
@@ -152,6 +176,7 @@ export default function ReceiptConfirmScreen() {
           quantite: item.quantite,
           unite: item.unite,
           dureeConservationJours: item.dureeConservationJours,
+          datePeremption: dateStrToISO(item.datePeremption),
           lieu: item.lieu,
         }));
 
@@ -225,6 +250,7 @@ export default function ReceiptConfirmScreen() {
                   {/* Row 2: qty input + unit picker + lieu (checked only) */}
                   {item.checked && (
                     <View style={styles.row2}>
+
                       {/* Quantity — direct text input, tap to type new value */}
                       <TextInput
                         style={styles.qtyInput}
@@ -262,6 +288,21 @@ export default function ReceiptConfirmScreen() {
                           />
                         </TouchableOpacity>
                       ))}
+                    </View>
+                  )}
+
+                  {/* Row 3: date de péremption (checked only) */}
+                  {item.checked && (
+                    <View style={styles.row3}>
+                      <Ionicons name="calendar-outline" size={14} color="#9CA3AF" />
+                      <TextInput
+                        style={styles.dateInput}
+                        value={item.datePeremption}
+                        onChangeText={(text) => updateDate(item.id, text)}
+                        placeholder={t('receiptConfirm.datePlaceholder')}
+                        placeholderTextColor="#9CA3AF"
+                        keyboardType="numeric"
+                      />
                     </View>
                   )}
                 </View>
@@ -336,6 +377,24 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   rowSpacer: { flex: 1 },
+
+  row3: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 36,
+    gap: 6,
+  },
+  dateInput: {
+    flex: 1,
+    fontSize: 13,
+    color: '#111111',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    backgroundColor: '#F9FAFB',
+  },
 
   checkbox: { padding: 2 },
 

--- a/app/add/receipt-confirm.tsx
+++ b/app/add/receipt-confirm.tsx
@@ -19,17 +19,21 @@ import { supabase } from '@/lib/supabase';
 import { addReceiptItemsToStock } from '@/features/stock/services/stockService';
 import type { Lieu, ReceiptItemDraft, ReceiptProduct } from '@/features/scanning/types';
 
-const LIEUX: { value: Lieu; label: string; icon: string }[] = [
-  { value: 'frigo', label: 'productConfirm.frigo', icon: 'snow-outline' },
-  { value: 'placard', label: 'productConfirm.placard', icon: 'cube-outline' },
-  { value: 'congelateur', label: 'productConfirm.congelateur', icon: 'thermometer-outline' },
+const LIEUX: { value: Lieu; icon: string }[] = [
+  { value: 'frigo', icon: 'snow-outline' },
+  { value: 'placard', icon: 'cube-outline' },
+  { value: 'congelateur', icon: 'thermometer-outline' },
 ];
+
+const UNITS = ['unite', 'g', 'kg', 'L', 'mL', 'lot'];
 
 interface EditableItem {
   id: string;
   nom: string;
   quantite: number;
+  quantiteStr: string;
   unite: string;
+  lieu: Lieu;
   checked: boolean;
   ingredientTag?: string;
   dureeConservationJours?: number;
@@ -45,13 +49,14 @@ export default function ReceiptConfirmScreen() {
       id: String(i),
       nom: item.nom,
       quantite: item.quantiteEstimee ?? 1,
+      quantiteStr: String(item.quantiteEstimee ?? 1),
       unite: item.unite ?? 'unite',
+      lieu: 'frigo',
       checked: true,
       ingredientTag: item.ingredientTag,
       dureeConservationJours: item.dureeConservationJours,
     })),
   );
-  const [lieu, setLieu] = useState<Lieu>('frigo');
   const [saving, setSaving] = useState(false);
 
   const checkedItems = editableItems.filter((item) => item.checked);
@@ -68,11 +73,52 @@ export default function ReceiptConfirmScreen() {
     );
   }
 
-  function updateQty(id: string, delta: number) {
+  function updateQtyStr(id: string, text: string) {
+    const parsed = parseFloat(text);
     setEditableItems((prev) =>
       prev.map((item) =>
-        item.id === id ? { ...item, quantite: Math.max(1, item.quantite + delta) } : item,
+        item.id === id
+          ? {
+              ...item,
+              quantiteStr: text,
+              ...(!isNaN(parsed) && parsed > 0 ? { quantite: parsed } : {}),
+            }
+          : item,
       ),
+    );
+  }
+
+  function normalizeQty(id: string) {
+    setEditableItems((prev) =>
+      prev.map((item) =>
+        item.id === id ? { ...item, quantiteStr: String(item.quantite) } : item,
+      ),
+    );
+  }
+
+  function updateUnite(id: string, unite: string) {
+    setEditableItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, unite } : item)),
+    );
+  }
+
+  function updateLieu(id: string, lieu: Lieu) {
+    setEditableItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, lieu } : item)),
+    );
+  }
+
+  function pickUnit(id: string, currentUnite: string) {
+    Alert.alert(
+      t('receiptConfirm.pickUnit'),
+      undefined,
+      [
+        ...UNITS.map((u) => ({
+          text: u === currentUnite ? `${u} ✓` : u,
+          onPress: () => updateUnite(id, u),
+        })),
+        { text: t('common.cancel'), style: 'cancel' as const },
+      ],
     );
   }
 
@@ -106,7 +152,7 @@ export default function ReceiptConfirmScreen() {
           quantite: item.quantite,
           unite: item.unite,
           dureeConservationJours: item.dureeConservationJours,
-          lieu,
+          lieu: item.lieu,
         }));
 
       await addReceiptItemsToStock(drafts, membre.foyer_id as string, session.user.id);
@@ -154,48 +200,68 @@ export default function ReceiptConfirmScreen() {
             <View style={styles.itemsList}>
               {editableItems.map((item) => (
                 <View key={item.id} style={[styles.itemCard, !item.checked && styles.itemCardUnchecked]}>
-                  <TouchableOpacity
-                    onPress={() => toggleItem(item.id)}
-                    style={styles.checkbox}
-                    hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
-                  >
-                    <Ionicons
-                      name={item.checked ? 'checkmark-circle' : 'ellipse-outline'}
-                      size={26}
-                      color={item.checked ? '#FF8400' : '#D1D5DB'}
+                  {/* Row 1: checkbox + name */}
+                  <View style={styles.row1}>
+                    <TouchableOpacity
+                      onPress={() => toggleItem(item.id)}
+                      style={styles.checkbox}
+                      hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+                    >
+                      <Ionicons
+                        name={item.checked ? 'checkmark-circle' : 'ellipse-outline'}
+                        size={26}
+                        color={item.checked ? '#FF8400' : '#D1D5DB'}
+                      />
+                    </TouchableOpacity>
+                    <TextInput
+                      style={[styles.itemName, !item.checked && styles.itemNameUnchecked]}
+                      value={item.nom}
+                      onChangeText={(text) => updateName(item.id, text)}
+                      editable={item.checked}
+                      placeholderTextColor="#9CA3AF"
                     />
-                  </TouchableOpacity>
+                  </View>
 
-                  <TextInput
-                    style={[styles.itemName, !item.checked && styles.itemNameUnchecked]}
-                    value={item.nom}
-                    onChangeText={(text) => updateName(item.id, text)}
-                    editable={item.checked}
-                    placeholderTextColor="#9CA3AF"
-                  />
-
+                  {/* Row 2: qty input + unit picker + lieu (checked only) */}
                   {item.checked && (
-                    <View style={styles.stepper}>
+                    <View style={styles.row2}>
+                      {/* Quantity — direct text input, tap to type new value */}
+                      <TextInput
+                        style={styles.qtyInput}
+                        value={item.quantiteStr}
+                        onChangeText={(text) => updateQtyStr(item.id, text)}
+                        onBlur={() => normalizeQty(item.id)}
+                        keyboardType="numeric"
+                        selectTextOnFocus
+                      />
+
+                      {/* Unit picker */}
                       <TouchableOpacity
-                        onPress={() => updateQty(item.id, -1)}
-                        style={styles.stepperBtn}
-                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 4 }}
+                        style={styles.unitBtn}
+                        onPress={() => pickUnit(item.id, item.unite)}
+                        hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
                       >
-                        <Ionicons name="remove" size={16} color="#6B7280" />
+                        <Text style={styles.unitBtnText}>{item.unite}</Text>
+                        <Ionicons name="chevron-down" size={10} color="#9CA3AF" />
                       </TouchableOpacity>
-                      <Text style={styles.stepperValue}>
-                        {item.quantite}
-                        {item.unite !== 'unite' && (
-                          <Text style={styles.stepperUnit}> {item.unite}</Text>
-                        )}
-                      </Text>
-                      <TouchableOpacity
-                        onPress={() => updateQty(item.id, 1)}
-                        style={styles.stepperBtn}
-                        hitSlop={{ top: 8, bottom: 8, left: 4, right: 8 }}
-                      >
-                        <Ionicons name="add" size={16} color="#6B7280" />
-                      </TouchableOpacity>
+
+                      <View style={styles.rowSpacer} />
+
+                      {/* Per-item lieu */}
+                      {LIEUX.map((l) => (
+                        <TouchableOpacity
+                          key={l.value}
+                          style={[styles.lieuBtn, item.lieu === l.value && styles.lieuBtnActive]}
+                          onPress={() => updateLieu(item.id, l.value)}
+                          hitSlop={{ top: 8, bottom: 8, left: 4, right: 4 }}
+                        >
+                          <Ionicons
+                            name={l.icon as never}
+                            size={15}
+                            color={item.lieu === l.value ? '#FF8400' : '#9CA3AF'}
+                          />
+                        </TouchableOpacity>
+                      ))}
                     </View>
                   )}
                 </View>
@@ -204,30 +270,8 @@ export default function ReceiptConfirmScreen() {
           )}
         </ScrollView>
 
-        {/* Sticky footer: lieu + CTA */}
+        {/* Sticky footer: CTA only */}
         <SafeAreaView edges={['bottom']} style={styles.footer}>
-          <View style={styles.lieuRow}>
-            <Text style={styles.lieuLabel}>{t('receiptConfirm.lieu')}</Text>
-            <View style={styles.lieuBtns}>
-              {LIEUX.map((l) => (
-                <TouchableOpacity
-                  key={l.value}
-                  style={[styles.lieuBtn, lieu === l.value && styles.lieuBtnActive]}
-                  onPress={() => setLieu(l.value)}
-                >
-                  <Ionicons
-                    name={l.icon as never}
-                    size={15}
-                    color={lieu === l.value ? '#FF8400' : '#9CA3AF'}
-                  />
-                  <Text style={[styles.lieuBtnText, lieu === l.value && styles.lieuBtnTextActive]}>
-                    {t(l.label)}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-          </View>
-
           <TouchableOpacity
             style={[styles.saveBtn, (saving || checkedItems.length === 0) && styles.saveBtnDisabled]}
             onPress={handleSaveAll}
@@ -276,16 +320,22 @@ const styles = StyleSheet.create({
 
   itemsList: { gap: 8 },
   itemCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
     backgroundColor: '#FFFFFF',
     borderRadius: 14,
     paddingHorizontal: 12,
     paddingVertical: 10,
-    gap: 10,
-    minHeight: 56,
+    gap: 6,
   },
   itemCardUnchecked: { backgroundColor: '#F9FAFB', opacity: 0.55 },
+
+  row1: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  row2: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 36, // aligns with name field (checkbox 26px + gap 10px)
+    gap: 6,
+  },
+  rowSpacer: { flex: 1 },
 
   checkbox: { padding: 2 },
 
@@ -298,38 +348,50 @@ const styles = StyleSheet.create({
   },
   itemNameUnchecked: { color: '#9CA3AF', textDecorationLine: 'line-through' },
 
-  stepper: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#F3F4F6',
-    borderRadius: 10,
-    paddingHorizontal: 4,
-    paddingVertical: 4,
-    gap: 6,
-  },
-  stepperBtn: {
-    width: 28,
-    height: 28,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#FFFFFF',
-    borderRadius: 8,
-  },
-  stepperValue: {
+  qtyInput: {
+    width: 58,
+    textAlign: 'center',
     fontSize: 14,
     fontWeight: '600',
     color: '#111111',
-    minWidth: 28,
-    textAlign: 'center',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 8,
+    paddingHorizontal: 6,
+    paddingVertical: 5,
+    backgroundColor: '#F9FAFB',
   },
-  stepperUnit: { fontSize: 12, fontWeight: '400', color: '#6B7280' },
+
+  unitBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 3,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    backgroundColor: '#F9FAFB',
+  },
+  unitBtnText: { fontSize: 12, fontWeight: '500', color: '#6B7280' },
+
+  lieuBtn: {
+    width: 30,
+    height: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    backgroundColor: '#F9FAFB',
+  },
+  lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
 
   footer: {
     backgroundColor: '#FFFFFF',
     paddingHorizontal: 16,
     paddingTop: 14,
     paddingBottom: 8,
-    gap: 12,
     borderTopWidth: 1,
     borderTopColor: '#F3F4F6',
     shadowColor: '#000',
@@ -338,25 +400,6 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
     elevation: 8,
   },
-  lieuRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
-  lieuLabel: { fontSize: 13, color: '#6B7280', fontWeight: '500' },
-  lieuBtns: { flex: 1, flexDirection: 'row', gap: 8 },
-  lieuBtn: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 5,
-    paddingVertical: 8,
-    borderRadius: 10,
-    borderWidth: 1,
-    borderColor: '#E5E7EB',
-    backgroundColor: '#F9FAFB',
-  },
-  lieuBtnActive: { backgroundColor: '#FFF3E0', borderColor: '#FF8400' },
-  lieuBtnText: { fontSize: 12, color: '#9CA3AF', fontWeight: '500' },
-  lieuBtnTextActive: { color: '#FF8400', fontWeight: '600' },
-
   saveBtn: {
     backgroundColor: '#FF8400',
     borderRadius: 14,

--- a/features/scanning/types.ts
+++ b/features/scanning/types.ts
@@ -38,6 +38,7 @@ export interface ReceiptItemDraft {
   quantite: number;
   unite: string;
   dureeConservationJours?: number;
+  datePeremption?: string | null; // ISO YYYY-MM-DD, prioritaire sur dureeConservationJours
   lieu: Lieu;
 }
 

--- a/features/stock/services/stockService.ts
+++ b/features/stock/services/stockService.ts
@@ -68,11 +68,12 @@ export async function addReceiptItemsToStock(
 
     if (produitError) throw produitError;
 
-    const expiryDate = item.dureeConservationJours
-      ? new Date(Date.now() + item.dureeConservationJours * 86_400_000)
-          .toISOString()
-          .split('T')[0]
-      : null;
+    const expiryDate = item.datePeremption
+      ?? (item.dureeConservationJours
+        ? new Date(Date.now() + item.dureeConservationJours * 86_400_000)
+            .toISOString()
+            .split('T')[0]
+        : null);
 
     const { error: stockError } = await supabase.from('stock_items').insert({
       foyer_id: foyerId,

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -110,7 +110,7 @@
     "itemCount": "{{count}} produit détecté",
     "itemCount_plural": "{{count}} produits détectés",
     "pickUnit": "Unité de mesure",
-    "datePlaceholder": "DLC (optionnel)",
+    "addDate": "Ajouter une DLC",
     "addAll": "Ajouter {{count}} produit au stock",
     "addAll_plural": "Ajouter {{count}} produits au stock",
     "empty": "Aucun produit. Revenez en arrière et réessayez.",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -97,6 +97,13 @@
     "orEmail": "ou avec votre email",
     "continueWithGoogle": "Continuer avec Google"
   },
+  "manualProduct": {
+    "title": "Ajout manuel",
+    "categorie": "Catégorie",
+    "categoriePlaceholder": "Sélectionner une catégorie (optionnel)",
+    "clearCategorie": "Retirer la catégorie",
+    "noResults": "Aucune catégorie trouvée"
+  },
   "receiptScan": {
     "title": "Scanner un ticket",
     "hint": "Cadrez le ticket de caisse en entier",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -109,7 +109,7 @@
     "title": "Vérifier les produits",
     "itemCount": "{{count}} produit détecté",
     "itemCount_plural": "{{count}} produits détectés",
-    "lieu": "Rangement (pour tous)",
+    "pickUnit": "Unité de mesure",
     "addAll": "Ajouter {{count}} produit au stock",
     "addAll_plural": "Ajouter {{count}} produits au stock",
     "empty": "Aucun produit. Revenez en arrière et réessayez.",

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -110,6 +110,7 @@
     "itemCount": "{{count}} produit détecté",
     "itemCount_plural": "{{count}} produits détectés",
     "pickUnit": "Unité de mesure",
+    "datePlaceholder": "DLC (optionnel)",
     "addAll": "Ajouter {{count}} produit au stock",
     "addAll_plural": "Ajouter {{count}} produits au stock",
     "empty": "Aucun produit. Revenez en arrière et réessayez.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/datetimepicker": "8.4.4",
         "@react-native-google-signin/google-signin": "^16.1.1",
         "@supabase/supabase-js": "^2.97.0",
         "expo": "~54.0.33",
@@ -3736,6 +3737,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
+      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-google-signin/google-signin": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-google-signin/google-signin": "^16.1.1",
     "@supabase/supabase-js": "^2.97.0",
     "expo": "~54.0.33",


### PR DESCRIPTION
## Summary
- Nouveau screen `manual-product.tsx` : formulaire complet (nom, catégorie, quantité, unité, DLC, lieu)
- Catégorie (ingredient_tag) optionnelle : modal fullscreen avec barre de recherche live sur la table `ingredients` Supabase
- Bouton "Ajouter manuellement" branché dans `add.tsx`
- Réutilise `addToStock` existant (source='manuel', sans EAN)

## Test plan
- [ ] Bouton "Ajouter manuellement" navigue vers le formulaire
- [ ] Nom obligatoire — erreur si vide
- [ ] Catégorie optionnelle — picker avec recherche
- [ ] Date de péremption via picker natif (iOS bottom sheet / Android dialog)
- [ ] Produit ajouté au bon lieu dans le stock

Refs #10