### PR TITLE
feat(recipes): seed ingredients + edge function seed-recipes

### DIFF
--- a/scripts/seed-ingredients.sql
+++ b/scripts/seed-ingredients.sql
@@ -1,0 +1,150 @@
+-- Seed ingredients table with normalized French food tags
+-- Run via: supabase db execute --file scripts/seed-ingredients.sql
+-- Or paste directly in Supabase SQL editor
+
+INSERT INTO ingredients (tag, categorie) VALUES
+  -- Produits laitiers
+  ('lait',            'Produits laitiers'),
+  ('beurre',          'Produits laitiers'),
+  ('creme',           'Produits laitiers'),
+  ('fromage',         'Produits laitiers'),
+  ('emmental',        'Produits laitiers'),
+  ('gruyere',         'Produits laitiers'),
+  ('parmesan',        'Produits laitiers'),
+  ('mozzarella',      'Produits laitiers'),
+  ('yaourt',          'Produits laitiers'),
+  ('lait_de_coco',    'Produits laitiers'),
+
+  -- Œufs
+  ('oeuf',            'Œufs'),
+
+  -- Viandes
+  ('poulet',          'Viandes'),
+  ('boeuf',           'Viandes'),
+  ('porc',            'Viandes'),
+  ('veau',            'Viandes'),
+  ('agneau',          'Viandes'),
+  ('lapin',           'Viandes'),
+  ('canard',          'Viandes'),
+  ('dinde',           'Viandes'),
+  ('lardons',         'Viandes'),
+  ('jambon',          'Viandes'),
+  ('saucisse',        'Viandes'),
+
+  -- Poissons & fruits de mer
+  ('saumon',          'Poissons'),
+  ('thon',            'Poissons'),
+  ('cabillaud',       'Poissons'),
+  ('sardine',         'Poissons'),
+  ('crevette',        'Poissons'),
+  ('moule',           'Poissons'),
+  ('coquille_saint_jacques', 'Poissons'),
+
+  -- Légumes
+  ('carotte',         'Légumes'),
+  ('tomate',          'Légumes'),
+  ('courgette',       'Légumes'),
+  ('aubergine',       'Légumes'),
+  ('poivron',         'Légumes'),
+  ('oignon',          'Légumes'),
+  ('ail',             'Légumes'),
+  ('echalote',        'Légumes'),
+  ('poireau',         'Légumes'),
+  ('brocoli',         'Légumes'),
+  ('epinard',         'Légumes'),
+  ('champignon',      'Légumes'),
+  ('pomme_de_terre',  'Légumes'),
+  ('patate_douce',    'Légumes'),
+  ('haricot_vert',    'Légumes'),
+  ('petits_pois',     'Légumes'),
+  ('salade',          'Légumes'),
+  ('chou',            'Légumes'),
+  ('chou_fleur',      'Légumes'),
+  ('celeri',          'Légumes'),
+  ('concombre',       'Légumes'),
+  ('radis',           'Légumes'),
+  ('asperge',         'Légumes'),
+  ('artichaut',       'Légumes'),
+  ('betterave',       'Légumes'),
+  ('navet',           'Légumes'),
+  ('panais',          'Légumes'),
+
+  -- Légumineuses
+  ('lentille',        'Légumineuses'),
+  ('pois_chiche',     'Légumineuses'),
+  ('haricot_blanc',   'Légumineuses'),
+  ('haricot_rouge',   'Légumineuses'),
+
+  -- Féculents
+  ('pates',           'Féculents'),
+  ('riz',             'Féculents'),
+  ('semoule',         'Féculents'),
+  ('farine',          'Féculents'),
+  ('pain',            'Féculents'),
+  ('pain_de_mie',     'Féculents'),
+
+  -- Fruits
+  ('pomme',           'Fruits'),
+  ('poire',           'Fruits'),
+  ('banane',          'Fruits'),
+  ('orange',          'Fruits'),
+  ('citron',          'Fruits'),
+  ('fraise',          'Fruits'),
+  ('framboise',       'Fruits'),
+  ('raisin',          'Fruits'),
+  ('peche',           'Fruits'),
+  ('abricot',         'Fruits'),
+  ('cerise',          'Fruits'),
+  ('mangue',          'Fruits'),
+  ('ananas',          'Fruits'),
+
+  -- Condiments & sauces
+  ('huile_olive',     'Condiments'),
+  ('huile',           'Condiments'),
+  ('sauce_tomate',    'Condiments'),
+  ('concentre_tomate','Condiments'),
+  ('moutarde',        'Condiments'),
+  ('vinaigre',        'Condiments'),
+  ('sauce_soja',      'Condiments'),
+  ('mayonnaise',      'Condiments'),
+
+  -- Épices & aromates
+  ('sel',             'Épices'),
+  ('poivre',          'Épices'),
+  ('cumin',           'Épices'),
+  ('curry',           'Épices'),
+  ('paprika',         'Épices'),
+  ('curcuma',         'Épices'),
+  ('herbes_de_provence', 'Épices'),
+  ('thym',            'Épices'),
+  ('laurier',         'Épices'),
+  ('basilic',         'Épices'),
+  ('persil',          'Épices'),
+  ('coriandre',       'Épices'),
+  ('romarin',         'Épices'),
+  ('cannelle',        'Épices'),
+  ('noix_de_muscade', 'Épices'),
+
+  -- Produits secs & sucre
+  ('sucre',           'Épicerie'),
+  ('sucre_roux',      'Épicerie'),
+  ('miel',            'Épicerie'),
+  ('chocolat',        'Épicerie'),
+  ('levure',          'Épicerie'),
+  ('bouillon',        'Épicerie'),
+  ('creme_de_coco',   'Épicerie'),
+
+  -- Fruits secs & noix
+  ('noix',            'Fruits secs'),
+  ('amande',          'Fruits secs'),
+  ('noisette',        'Fruits secs'),
+  ('noix_de_cajou',   'Fruits secs'),
+  ('raisin_sec',      'Fruits secs'),
+  ('olive',           'Fruits secs'),
+
+  -- Boissons culinaires
+  ('vin_blanc',       'Boissons'),
+  ('vin_rouge',       'Boissons'),
+  ('biere',           'Boissons')
+
+ON CONFLICT (tag) DO NOTHING;

--- a/supabase/functions/seed-recipes/index.ts
+++ b/supabase/functions/seed-recipes/index.ts
@@ -1,0 +1,226 @@
+/**
+ * Edge Function: seed-recipes
+ *
+ * Génère N recettes françaises via Gemini et les insère en base.
+ * À appeler UNE seule fois (ou avec un count réduit pour tester).
+ *
+ * Invocation :
+ *   supabase functions invoke seed-recipes --no-verify-jwt \
+ *     --body '{"count": 10, "secret": "<SEED_SECRET>"}'
+ *
+ * La variable SEED_SECRET doit être définie via :
+ *   supabase secrets set SEED_SECRET=<valeur>
+ */
+
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+
+const GEMINI_API_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+
+interface RecetteIngredient {
+  tag: string;
+  quantite: number;
+  unite: string;
+  est_optionnel: boolean;
+}
+
+interface RecetteGemini {
+  titre: string;
+  portions_base: number;
+  temps_prep_min: number;
+  temps_cuisson_min: number;
+  preferences: string[];
+  instructions: { etape: number; texte: string }[];
+  ingredients: RecetteIngredient[];
+}
+
+interface GeminiResponse {
+  candidates?: Array<{
+    content?: { parts?: Array<{ text?: string }> };
+  }>;
+}
+
+function buildPrompt(tags: string[], count: number): string {
+  return `Tu es un chef cuisinier expert en cuisine française du quotidien.
+
+Génère exactement ${count} recettes françaises traditionnelles et familiales DISTINCTES (pas de restaurant).
+Utilise UNIQUEMENT les tags d'ingrédients de la liste fournie.
+
+Liste des tags disponibles :
+${tags.join(', ')}
+
+Retourne un objet JSON avec une clé "recettes" contenant un tableau de ${count} recettes.
+Chaque recette doit avoir ces champs :
+- titre: string (nom de la recette en français)
+- portions_base: number (2 ou 4)
+- temps_prep_min: number (entre 5 et 45)
+- temps_cuisson_min: number (entre 0 et 90)
+- preferences: string[] (valeurs possibles : "vegetarien", "vegan", "sans_gluten", "sans_lactose", ou tableau vide)
+- instructions: tableau de {"etape": number, "texte": string} (4 à 7 étapes)
+  - Les quantités dans les instructions doivent être RELATIVES ("la moitié des carottes", "le reste de la sauce")
+  - JAMAIS de quantités absolues dans les instructions
+- ingredients: tableau de {"tag": string, "quantite": number, "unite": string, "est_optionnel": boolean}
+  - 3 à 7 ingrédients par recette
+  - UNIQUEMENT des tags de la liste fournie
+  - quantite : quantité totale pour portions_base personnes
+  - unite : "g", "kg", "ml", "L", "unite", "cas" (cuillère à soupe), "cac" (cuillère à café), "pincee"
+
+Règles :
+- Chaque recette doit être différente
+- Mélange des recettes végétariennes et carnées
+- Cuisine familiale simple : gratin, quiche, soupe, tajine, risotto, etc.
+- Retourne UNIQUEMENT le JSON valide : {"recettes": [...]}`;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'authorization, content-type',
+      },
+    });
+  }
+
+  try {
+    const body = await req.json() as { count?: number; secret?: string };
+    const count = Math.min(body.count ?? 10, 50); // max 50 par appel
+
+    // Secret check
+    const expectedSecret = Deno.env.get('SEED_SECRET');
+    if (expectedSecret && body.secret !== expectedSecret) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const geminiKey = Deno.env.get('GEMINI_API_KEY');
+    if (!geminiKey) throw new Error('GEMINI_API_KEY not configured');
+
+    // Supabase client with service role to bypass RLS
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    );
+
+    // Fetch available ingredient tags
+    const { data: ingredients, error: ingError } = await supabase
+      .from('ingredients')
+      .select('tag')
+      .order('tag');
+
+    if (ingError) throw ingError;
+    if (!ingredients || ingredients.length === 0) {
+      return new Response(
+        JSON.stringify({ error: 'No ingredients in DB. Run seed-ingredients.sql first.' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const tags = ingredients.map((i: { tag: string }) => i.tag);
+    console.log(`[seed-recipes] ${tags.length} tags disponibles, génération de ${count} recettes…`);
+
+    // Call Gemini
+    const geminiRes = await fetch(`${GEMINI_API_URL}?key=${geminiKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: buildPrompt(tags, count) }] }],
+        generationConfig: {
+          temperature: 0.8,
+          responseMimeType: 'application/json',
+          thinkingConfig: { thinkingBudget: 0 },
+        },
+      }),
+    });
+
+    if (!geminiRes.ok) {
+      const err = await geminiRes.text();
+      console.error('[seed-recipes] Gemini error:', err);
+      return new Response(JSON.stringify({ error: 'GEMINI_ERROR', detail: err }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const geminiData = await geminiRes.json() as GeminiResponse;
+    const rawText = geminiData.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+
+    let parsed: { recettes?: RecetteGemini[] };
+    try {
+      parsed = JSON.parse(rawText);
+    } catch {
+      console.error('[seed-recipes] JSON parse error:', rawText.slice(0, 500));
+      return new Response(JSON.stringify({ error: 'PARSE_ERROR' }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const recettes = parsed.recettes ?? [];
+    const tagSet = new Set(tags);
+    const results = { inserted: 0, skipped: 0, errors: [] as string[] };
+
+    for (const r of recettes) {
+      try {
+        // Validate & filter ingredients to known tags only
+        const validIngredients = (r.ingredients ?? []).filter((i) => tagSet.has(i.tag));
+        if (validIngredients.length === 0) {
+          results.skipped++;
+          console.warn(`[seed-recipes] Skipped "${r.titre}": no valid ingredient tags`);
+          continue;
+        }
+
+        // Insert recette
+        const { data: inserted, error: recetteError } = await supabase
+          .from('recettes')
+          .insert({
+            titre: r.titre,
+            portions_base: r.portions_base ?? 4,
+            temps_prep_min: r.temps_prep_min ?? null,
+            temps_cuisson_min: r.temps_cuisson_min ?? null,
+            instructions_json: r.instructions ?? [],
+            preferences: r.preferences ?? [],
+            source: 'seed',
+          })
+          .select('id')
+          .single();
+
+        if (recetteError) throw recetteError;
+
+        // Insert ingredients
+        const { error: ingInsertError } = await supabase
+          .from('recette_ingredients')
+          .insert(
+            validIngredients.map((i) => ({
+              recette_id: inserted.id,
+              ingredient_tag: i.tag,
+              quantite_totale: i.quantite,
+              unite: i.unite,
+              est_optionnel: i.est_optionnel ?? false,
+            })),
+          );
+
+        if (ingInsertError) throw ingInsertError;
+
+        results.inserted++;
+        console.log(`[seed-recipes] ✓ "${r.titre}" (${validIngredients.length} ingrédients)`);
+      } catch (err) {
+        results.errors.push(`"${r.titre}": ${(err as Error).message}`);
+        console.error(`[seed-recipes] ✗ "${r.titre}":`, err);
+      }
+    }
+
+    return new Response(JSON.stringify({ ...results, total: recettes.length }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[seed-recipes] Unexpected error:', err);
+    return new Response(JSON.stringify({ error: 'INTERNAL_ERROR', detail: String(err) }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- `scripts/seed-ingredients.sql` : ~100 tags d'ingrédients normalisés avec catégories
- `supabase/functions/seed-recipes` : Edge Function qui génère N recettes via Gemini (clé côté Supabase) et insère dans `recettes` + `recette_ingredients`

## Utilisation
```bash
# 1. Seed les ingrédients (SQL editor Supabase ou CLI)
supabase db execute --file scripts/seed-ingredients.sql

# 2. Déployer la fonction
supabase functions deploy seed-recipes

# 3. Générer 10 recettes (test)
supabase functions invoke seed-recipes --no-verify-jwt \
  --body '{"count":10,"secret":"<SEED_SECRET>"}'
```

## Détails
- Passe la liste des tags existants à Gemini → recettes cohérentes avec la base
- Instructions relatives ("la moitié des carottes") — pas de scaling LLM
- Filtre les tags inconnus avant insertion (protection FK)
- `max 50 par appel` pour éviter les timeouts

Refs #14