### PR TITLE
feat(recipes): scoring SQL + écran suggestions

### DIFF
--- a/app/(tabs)/recipes.tsx
+++ b/app/(tabs)/recipes.tsx
@@ -1,26 +1,237 @@
-import { StyleSheet, Text, View } from 'react-native';
+import { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { router, useFocusEffect } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useTranslation } from 'react-i18next';
+import { useRecipes, type FavoriteRecipe, type ScoredRecipe } from '@/features/recipes/hooks/useRecipes';
+
+type Tab = 'suggestions' | 'favorites';
+
+function Scorebadge({ score }: { score: number }) {
+  const pct = Math.round(score * 100);
+  const isHigh = score >= 0.8;
+  const isMid = score >= 0.5;
+  const color = isHigh ? '#16A34A' : isMid ? '#F59E0B' : '#9CA3AF';
+  const bg = isHigh ? '#DCFCE7' : isMid ? '#FEF3C7' : '#F3F4F6';
+  const label = score >= 1 ? '✓ Complet' : `${pct}%`;
+  return (
+    <View style={[styles.scoreBadge, { backgroundColor: bg }]}>
+      <Text style={[styles.scoreBadgeText, { color }]}>{label}</Text>
+    </View>
+  );
+}
+
+function TimeChip({ minutes }: { minutes: number | null }) {
+  if (!minutes) return null;
+  return (
+    <View style={styles.timeChip}>
+      <Ionicons name="time-outline" size={12} color="#9CA3AF" />
+      <Text style={styles.timeChipText}>{minutes} min</Text>
+    </View>
+  );
+}
+
+function SuggestionCard({ item }: { item: ScoredRecipe }) {
+  const missing = item.missingTags.length;
+  return (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => router.push({ pathname: '/recipes/[id]', params: { id: item.id } })}
+    >
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle} numberOfLines={2}>{item.titre}</Text>
+        <Scorebadge score={item.score} />
+      </View>
+      <View style={styles.cardFooter}>
+        <TimeChip minutes={(item.tempsPrepMin ?? 0) + (item.tempsCuissonMin ?? 0)} />
+        {missing > 0 && (
+          <View style={styles.missingChip}>
+            <Ionicons name="alert-circle-outline" size={12} color="#EF4444" />
+            <Text style={styles.missingChipText}>
+              {missing} ingrédient{missing > 1 ? 's' : ''} manquant{missing > 1 ? 's' : ''}
+            </Text>
+          </View>
+        )}
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+function FavoriteCard({ item }: { item: FavoriteRecipe }) {
+  return (
+    <TouchableOpacity
+      style={styles.card}
+      onPress={() => router.push({ pathname: '/recipes/[id]', params: { id: item.id } })}
+    >
+      <View style={styles.cardHeader}>
+        <Text style={styles.cardTitle} numberOfLines={2}>{item.titre}</Text>
+        <Ionicons name="heart" size={18} color="#EF4444" />
+      </View>
+      <View style={styles.cardFooter}>
+        <TimeChip minutes={(item.tempsPrepMin ?? 0) + (item.tempsCuissonMin ?? 0)} />
+      </View>
+    </TouchableOpacity>
+  );
+}
 
 export default function RecipesScreen() {
   const { t } = useTranslation();
+  const { suggestions, favorites, loading, refreshing, refetch } = useRecipes();
+  const [activeTab, setActiveTab] = useState<Tab>('suggestions');
+
+  useFocusEffect(useCallback(() => { refetch(); }, []));
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['top']}>
+      {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>{t('recipes.title')}</Text>
       </View>
-      <View style={styles.emptyState}>
-        <Text style={styles.emptyText}>{t('recipes.emptyState')}</Text>
+
+      {/* Tabs */}
+      <View style={styles.tabBar}>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'suggestions' && styles.tabActive]}
+          onPress={() => setActiveTab('suggestions')}
+        >
+          <Ionicons name="bulb-outline" size={15} color={activeTab === 'suggestions' ? '#FF8400' : '#9CA3AF'} />
+          <Text style={[styles.tabLabel, activeTab === 'suggestions' && styles.tabLabelActive]}>
+            {t('recipes.suggestions')}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.tab, activeTab === 'favorites' && styles.tabActive]}
+          onPress={() => setActiveTab('favorites')}
+        >
+          <Ionicons name="heart-outline" size={15} color={activeTab === 'favorites' ? '#FF8400' : '#9CA3AF'} />
+          <Text style={[styles.tabLabel, activeTab === 'favorites' && styles.tabLabelActive]}>
+            {t('recipes.favorites')}
+          </Text>
+          {favorites.length > 0 && (
+            <View style={[styles.tabBadge, activeTab === 'favorites' && styles.tabBadgeActive]}>
+              <Text style={[styles.tabBadgeText, activeTab === 'favorites' && styles.tabBadgeTextActive]}>
+                {favorites.length}
+              </Text>
+            </View>
+          )}
+        </TouchableOpacity>
       </View>
+
+      {loading ? (
+        <View style={styles.centered}>
+          <ActivityIndicator color="#FF8400" size="large" />
+        </View>
+      ) : activeTab === 'suggestions' ? (
+        suggestions.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Ionicons name="basket-outline" size={44} color="#D1D5DB" />
+            <Text style={styles.emptyTitle}>{t('recipes.emptySuggestionsTitle')}</Text>
+            <Text style={styles.emptySubtitle}>{t('recipes.emptySuggestionsSub')}</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={suggestions}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => <SuggestionCard item={item} />}
+            contentContainerStyle={styles.listContent}
+            ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
+            showsVerticalScrollIndicator={false}
+            refreshing={refreshing}
+            onRefresh={refetch}
+          />
+        )
+      ) : (
+        favorites.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Ionicons name="heart-outline" size={44} color="#D1D5DB" />
+            <Text style={styles.emptyTitle}>{t('recipes.emptyFavoritesTitle')}</Text>
+            <Text style={styles.emptySubtitle}>{t('recipes.emptyFavoritesSub')}</Text>
+          </View>
+        ) : (
+          <FlatList
+            data={favorites}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => <FavoriteCard item={item} />}
+            contentContainerStyle={styles.listContent}
+            ItemSeparatorComponent={() => <View style={{ height: 10 }} />}
+            showsVerticalScrollIndicator={false}
+            refreshing={refreshing}
+            onRefresh={refetch}
+          />
+        )
+      )}
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#F2F3F0' },
-  header: { paddingHorizontal: 20, paddingTop: 8, paddingBottom: 16 },
+
+  header: { paddingHorizontal: 20, paddingTop: 8, paddingBottom: 4 },
   title: { fontSize: 22, fontWeight: '700', color: '#111111' },
-  emptyState: { flex: 1, alignItems: 'center', justifyContent: 'center' },
-  emptyText: { fontSize: 15, color: '#6B7280', textAlign: 'center', paddingHorizontal: 40 },
+
+  // Tab bar
+  tabBar: {
+    flexDirection: 'row',
+    marginHorizontal: 16,
+    marginBottom: 12,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    padding: 4,
+  },
+  tab: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 5,
+    paddingVertical: 9,
+    borderRadius: 10,
+  },
+  tabActive: { backgroundColor: '#FFF3E0' },
+  tabLabel: { fontSize: 13, fontWeight: '500', color: '#9CA3AF' },
+  tabLabelActive: { color: '#FF8400', fontWeight: '600' },
+  tabBadge: { backgroundColor: '#E5E7EB', borderRadius: 8, paddingHorizontal: 6, paddingVertical: 1 },
+  tabBadgeActive: { backgroundColor: '#FDBA74' },
+  tabBadgeText: { fontSize: 11, fontWeight: '600', color: '#6B7280' },
+  tabBadgeTextActive: { color: '#FFFFFF' },
+
+  // Cards
+  listContent: { paddingHorizontal: 16, paddingBottom: 24 },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    paddingHorizontal: 14,
+    paddingVertical: 14,
+    gap: 8,
+  },
+  cardHeader: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+  cardTitle: { flex: 1, fontSize: 15, fontWeight: '600', color: '#111111' },
+  cardFooter: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+
+  // Score badge
+  scoreBadge: { paddingHorizontal: 8, paddingVertical: 3, borderRadius: 20 },
+  scoreBadgeText: { fontSize: 12, fontWeight: '700' },
+
+  // Time chip
+  timeChip: { flexDirection: 'row', alignItems: 'center', gap: 3 },
+  timeChipText: { fontSize: 12, color: '#9CA3AF' },
+
+  // Missing chip
+  missingChip: { flexDirection: 'row', alignItems: 'center', gap: 4 },
+  missingChipText: { fontSize: 12, color: '#EF4444' },
+
+  // States
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  emptyState: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 10, paddingHorizontal: 40 },
+  emptyTitle: { fontSize: 16, fontWeight: '600', color: '#374151', textAlign: 'center' },
+  emptySubtitle: { fontSize: 13, color: '#9CA3AF', textAlign: 'center' },
 });

--- a/features/recipes/hooks/useRecipes.ts
+++ b/features/recipes/hooks/useRecipes.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+
+export interface ScoredRecipe {
+  id: string;
+  titre: string;
+  score: number; // 0–1
+  matchedCount: number;
+  totalCount: number;
+  missingTags: string[];
+  tempsPrepMin: number | null;
+  tempsCuissonMin: number | null;
+  portionsBase: number;
+  preferences: string[];
+}
+
+export interface FavoriteRecipe {
+  id: string;
+  titre: string;
+  tempsPrepMin: number | null;
+  tempsCuissonMin: number | null;
+  portionsBase: number;
+}
+
+export function useRecipes() {
+  const [suggestions, setSuggestions] = useState<ScoredRecipe[]>([]);
+  const [favorites, setFavorites] = useState<FavoriteRecipe[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async (isRefresh = false) => {
+    if (isRefresh) setRefreshing(true);
+    else setLoading(true);
+
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) return;
+
+      const { data: membre } = await supabase
+        .from('foyer_membres')
+        .select('foyer_id')
+        .eq('user_id', session.user.id)
+        .maybeSingle();
+
+      if (!membre?.foyer_id) return;
+
+      const foyerId = membre.foyer_id as string;
+
+      const [rpcRes, favRes] = await Promise.all([
+        supabase.rpc('get_scored_recipes', { p_foyer_id: foyerId, p_limit: 20 }),
+        supabase
+          .from('foyer_recettes_favorites')
+          .select('recettes(id, titre, temps_prep_min, temps_cuisson_min, portions_base)')
+          .eq('foyer_id', foyerId),
+      ]);
+
+      if (rpcRes.data) {
+        setSuggestions(
+          (rpcRes.data as any[]).map((r) => ({
+            id: r.id as string,
+            titre: r.titre as string,
+            score: Number(r.score),
+            matchedCount: Number(r.matched_count),
+            totalCount: Number(r.total_count),
+            missingTags: (r.missing_tags as string[]) ?? [],
+            tempsPrepMin: r.temps_prep_min as number | null,
+            tempsCuissonMin: r.temps_cuisson_min as number | null,
+            portionsBase: r.portions_base as number,
+            preferences: (r.preferences as string[]) ?? [],
+          })),
+        );
+      }
+
+      if (favRes.data) {
+        setFavorites(
+          (favRes.data as any[])
+            .map((row) => row.recettes)
+            .filter(Boolean)
+            .map((r: any) => ({
+              id: r.id as string,
+              titre: r.titre as string,
+              tempsPrepMin: r.temps_prep_min as number | null,
+              tempsCuissonMin: r.temps_cuisson_min as number | null,
+              portionsBase: r.portions_base as number,
+            })),
+        );
+      }
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  return {
+    suggestions,
+    favorites,
+    loading,
+    refreshing,
+    refetch: () => load(true),
+  };
+}

--- a/lib/i18n/locales/fr.json
+++ b/lib/i18n/locales/fr.json
@@ -134,10 +134,12 @@
   },
   "recipes": {
     "title": "Recettes",
-    "emptyState": "Aucune recette trouvée",
-    "search": "Rechercher une recette",
-    "ingredients": "Ingrédients",
-    "steps": "Étapes"
+    "suggestions": "Suggestions",
+    "favorites": "Favoris",
+    "emptySuggestionsTitle": "Aucune suggestion",
+    "emptySuggestionsSub": "Ajoutez des produits à votre stock pour voir des recettes adaptées.",
+    "emptyFavoritesTitle": "Pas encore de favoris",
+    "emptyFavoritesSub": "Marquez des recettes comme favorites depuis leur page détail."
   },
   "settings": {
     "title": "Réglages",

--- a/scripts/create-scoring-rpc.sql
+++ b/scripts/create-scoring-rpc.sql
@@ -1,0 +1,77 @@
+-- Supabase RPC : scoring de recettes par rapport au stock du foyer
+-- Exécuter via : scripts/run-sql.mjs scripts/create-scoring-rpc.sql
+
+CREATE OR REPLACE FUNCTION get_scored_recipes(
+  p_foyer_id  uuid,
+  p_limit     integer DEFAULT 10
+)
+RETURNS TABLE (
+  id                uuid,
+  titre             text,
+  score             numeric,
+  matched_count     bigint,
+  total_count       bigint,
+  missing_tags      text[],
+  temps_prep_min    integer,
+  temps_cuisson_min integer,
+  portions_base     integer,
+  preferences       text[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH stock_tags AS (
+    SELECT DISTINCT ingredient_tag
+    FROM   stock_items
+    WHERE  foyer_id = p_foyer_id
+      AND  ingredient_tag IS NOT NULL
+  ),
+  scored AS (
+    SELECT
+      r.id,
+      r.titre,
+      r.temps_prep_min,
+      r.temps_cuisson_min,
+      r.portions_base,
+      r.preferences,
+      COUNT(ri.ingredient_tag) FILTER (WHERE ri.est_optionnel = false)
+        AS total_required,
+      COUNT(ri.ingredient_tag) FILTER (
+        WHERE ri.est_optionnel = false
+          AND ri.ingredient_tag IN (SELECT ingredient_tag FROM stock_tags)
+      ) AS matched_required,
+      ARRAY_REMOVE(
+        ARRAY_AGG(ri.ingredient_tag) FILTER (
+          WHERE ri.est_optionnel = false
+            AND ri.ingredient_tag NOT IN (SELECT ingredient_tag FROM stock_tags)
+        ),
+        NULL
+      ) AS missing
+    FROM recettes r
+    JOIN recette_ingredients ri ON ri.recette_id = r.id
+    GROUP BY r.id
+  )
+  SELECT
+    s.id,
+    s.titre,
+    CASE
+      WHEN s.total_required = 0 THEN 0
+      ELSE ROUND(s.matched_required::numeric / s.total_required::numeric, 2)
+    END                         AS score,
+    s.matched_required          AS matched_count,
+    s.total_required            AS total_count,
+    COALESCE(s.missing, '{}')   AS missing_tags,
+    s.temps_prep_min,
+    s.temps_cuisson_min,
+    s.portions_base,
+    s.preferences
+  FROM scored s
+  WHERE s.total_required > 0
+  ORDER BY score DESC, s.matched_required DESC
+  LIMIT p_limit;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION get_scored_recipes TO authenticated;


### PR DESCRIPTION
## Summary
- RPC `get_scored_recipes` : scoring SQL côté serveur, score = matched/total, ordered by score DESC
- Hook `useRecipes` : suggestions scorées + favoris du foyer en 2 requêtes parallèles
- Screen `recipes.tsx` : onglets Suggestions/Favoris, badge score coloré, chip ingrédients manquants

## Test plan
- [ ] Les recettes apparaissent triées par score décroissant
- [ ] Badge vert ≥ 80%, orange ≥ 50%, gris < 50%
- [ ] "X ingrédients manquants" affiché si incomplet
- [ ] Onglet Favoris vide si aucun favori
- [ ] Pull-to-refresh recharge les deux listes

Refs #15