### PR TITLE
feat(design-system): fondations — theme.ts + fonts + Lucide icons

### DIFF
--- a/app.json
+++ b/app.json
@@ -56,7 +56,8 @@
           "iosUrlScheme": "com.googleusercontent.apps.1068503426751-pl3cib3g60llhit4ltahiaeb5t57v5ca"
         }
       ],
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      "expo-font"
     ],
     "extra": {
       "router": {},

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,16 +5,33 @@ import { ActivityIndicator, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Stack, router } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useFonts } from 'expo-font';
+import {
+  Gabarito_400Regular,
+  Gabarito_500Medium,
+  Gabarito_600SemiBold,
+  Gabarito_700Bold,
+} from '@expo-google-fonts/gabarito';
+import { Graduate_400Regular } from '@expo-google-fonts/graduate';
 import { useAuth } from '@/features/auth/hooks/useAuth';
 import { useFoyer } from '@/features/foyer/hooks/useFoyer';
 import { createFoyer } from '@/features/foyer/services/foyerService';
+import { colors } from '@/lib/theme';
 
 export default function RootLayout() {
+  const [fontsLoaded] = useFonts({
+    Gabarito_400Regular,
+    Gabarito_500Medium,
+    Gabarito_600SemiBold,
+    Gabarito_700Bold,
+    Graduate_400Regular,
+  });
+
   const { session, loading: authLoading } = useAuth();
   const { hasFoyer, loading: foyerLoading } = useFoyer(session?.user.id);
   const creatingFoyer = useRef(false);
 
-  const loading = authLoading || (!!session && foyerLoading);
+  const loading = !fontsLoaded || authLoading || (!!session && foyerLoading);
 
   useEffect(() => {
     if (loading) return;
@@ -42,8 +59,8 @@ export default function RootLayout() {
 
   if (loading) {
     return (
-      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#F2F3F0' }}>
-        <ActivityIndicator size="large" color="#FF8400" />
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: colors.light.background }}>
+        <ActivityIndicator size="large" color={colors.light.primary} />
       </View>
     );
   }

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,215 @@
+import { Gabarito_400Regular, Gabarito_500Medium, Gabarito_600SemiBold, Gabarito_700Bold } from '@expo-google-fonts/gabarito';
+import { Graduate_400Regular } from '@expo-google-fonts/graduate';
+
+// ─── Fonts ────────────────────────────────────────────────────────────────────
+
+export const fonts = {
+  Gabarito_400Regular,
+  Gabarito_500Medium,
+  Gabarito_600SemiBold,
+  Gabarito_700Bold,
+  Graduate_400Regular,
+};
+
+export const fontFamily = {
+  body: 'Gabarito_400Regular',
+  bodyMedium: 'Gabarito_500Medium',
+  bodySemiBold: 'Gabarito_600SemiBold',
+  bodyBold: 'Gabarito_700Bold',
+  quantity: 'Graduate_400Regular',
+} as const;
+
+export const fontSize = {
+  xs: 11,
+  sm: 13,
+  md: 15,
+  lg: 17,
+  xl: 20,
+  xxl: 24,
+  xxxl: 28,
+} as const;
+
+// ─── Colors ───────────────────────────────────────────────────────────────────
+
+const palette = {
+  // Brand
+  orange300: '#FFAB61',
+  orange400: '#FF8C35',
+  orange500: '#FF7300',
+  orange50:  '#FFF8F0',
+  orange100: '#FFE8CC',
+
+  // Neutrals
+  white:   '#FFFFFF',
+  gray50:  '#F9FAFB',
+  gray100: '#F3F4F6',
+  gray200: '#E5E7EB',
+  gray300: '#D1D5DB',
+  gray400: '#9CA3AF',
+  gray500: '#6B7280',
+  gray600: '#4B5563',
+  gray700: '#374151',
+  gray800: '#1F2937',
+  gray900: '#111827',
+  black:   '#000000',
+
+  // Dark surfaces
+  dark50:  '#2C2C2E',
+  dark100: '#1C1C1E',
+  dark200: '#141414',
+  dark300: '#0F0F0F',
+
+  // Semantic
+  green500:  '#16A34A',
+  green50:   '#DCFCE7',
+  amber500:  '#F59E0B',
+  amber50:   '#FEF3C7',
+  red500:    '#EF4444',
+  red50:     '#FEE2E2',
+} as const;
+
+export type ColorScheme = 'light' | 'dark';
+
+export const colors = {
+  light: {
+    // Brand
+    primary:   palette.orange500,
+    primaryBg: palette.orange50,
+
+    // Backgrounds
+    background: palette.gray50,
+    surface:    palette.white,
+    surfaceAlt: palette.gray100,
+
+    // Text
+    text: {
+      primary:   palette.gray900,
+      secondary: palette.gray700,
+      muted:     palette.gray500,
+      inverse:   palette.white,
+    },
+
+    // Border
+    border:       palette.gray200,
+    borderStrong: palette.gray300,
+
+    // Semantic — expiry badges
+    expiry: {
+      urgent:    { text: palette.red500,   bg: palette.red50   }, // aujourd'hui / demain
+      warning:   { text: palette.amber500, bg: palette.amber50 }, // 2–7 jours
+      safe:      { text: palette.green500, bg: palette.green50 }, // > 7 jours
+    },
+
+    // Tab bar
+    tabBar: {
+      background: palette.white,
+      active:     palette.orange500,
+      inactive:   palette.gray400,
+    },
+
+    // Icon button (LocationFilter)
+    iconButton: {
+      activeBg:     palette.orange50,
+      activeColor:  palette.orange500,
+      inactiveBg:   palette.gray100,
+      inactiveColor: palette.gray400,
+    },
+  },
+
+  dark: {
+    // Brand
+    primary:   palette.orange400,
+    primaryBg: '#2A1A00',
+
+    // Backgrounds
+    background: palette.dark300,
+    surface:    palette.dark100,
+    surfaceAlt: palette.dark50,
+
+    // Text
+    text: {
+      primary:   palette.gray50,
+      secondary: palette.gray300,
+      muted:     palette.gray500,
+      inverse:   palette.gray900,
+    },
+
+    // Border
+    border:       palette.dark50,
+    borderStrong: palette.gray700,
+
+    // Semantic — expiry badges
+    expiry: {
+      urgent:  { text: '#FF6B6B', bg: '#2D1515' },
+      warning: { text: '#FFC46B', bg: '#2D2010' },
+      safe:    { text: '#6BCB8B', bg: '#102D1A' },
+    },
+
+    // Tab bar
+    tabBar: {
+      background: palette.dark100,
+      active:     palette.orange400,
+      inactive:   palette.gray600,
+    },
+
+    // Icon button (LocationFilter)
+    iconButton: {
+      activeBg:      '#2A1A00',
+      activeColor:   palette.orange400,
+      inactiveBg:    palette.dark50,
+      inactiveColor: palette.gray500,
+    },
+  },
+} as const;
+
+// ─── Spacing ──────────────────────────────────────────────────────────────────
+
+export const spacing = {
+  xs:   4,
+  sm:   8,
+  md:   12,
+  lg:   16,
+  xl:   20,
+  xxl:  24,
+  xxxl: 32,
+} as const;
+
+// ─── Border Radius ────────────────────────────────────────────────────────────
+
+export const radius = {
+  sm:   8,
+  md:   12,
+  lg:   16,
+  xl:   24,
+  pill: 999,
+} as const;
+
+// ─── Shadows ──────────────────────────────────────────────────────────────────
+
+export const shadows = {
+  sm: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.08,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  md: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.12,
+    shadowRadius: 8,
+    elevation: 4,
+  },
+  lg: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 8 },
+    shadowOpacity: 0.16,
+    shadowRadius: 16,
+    elevation: 8,
+  },
+} as const;
+
+// ─── Expiry threshold ─────────────────────────────────────────────────────────
+
+export const EXPIRY_BADGE_THRESHOLD_DAYS = 7;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "fridgy",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/gabarito": "^0.4.2",
+        "@expo-google-fonts/graduate": "^0.4.1",
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "8.4.4",
@@ -18,18 +20,21 @@
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.20",
+        "expo-font": "~14.0.11",
         "expo-image-manipulator": "~14.0.8",
         "expo-linking": "~8.0.11",
         "expo-localization": "~17.0.8",
         "expo-router": "~6.0.23",
         "expo-status-bar": "~3.0.9",
         "i18next": "^25.8.12",
+        "lucide-react-native": "^0.576.0",
         "react": "19.1.0",
         "react-i18next": "^16.5.4",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
+        "react-native-svg": "15.12.1",
         "react-native-url-polyfill": "^3.0.0"
       },
       "devDependencies": {
@@ -1796,6 +1801,16 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@expo-google-fonts/gabarito": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/gabarito/-/gabarito-0.4.2.tgz",
+      "integrity": "sha512-elUHkbpZ7SO/odEdWnNlDpXNNei0mNPLqBvfVfgqopPD2oER55mphO9aIh22GNc1WSFRVhPj2ny6hu4iPfHAiA=="
+    },
+    "node_modules/@expo-google-fonts/graduate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/graduate/-/graduate-0.4.1.tgz",
+      "integrity": "sha512-Tesv27GXQ9QJ6cnIQBHR6xbiyFoRnjG0r3VG72dWhrmI1C+EnqGiI0eyDkW0fHrRpTrdKaltgxc2RHl7OSvnLg=="
     },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
@@ -5803,6 +5818,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -6499,6 +6519,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -6809,6 +6875,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -6831,6 +6932,33 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -7978,6 +8106,19 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-font": {
+      "version": "14.0.11",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
+      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
+      "dependencies": {
+        "fontfaceobserver": "^2.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-image-loader": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
@@ -8751,20 +8892,6 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/expo/node_modules/expo-font": {
-      "version": "14.0.11",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
-      "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
-      "license": "MIT",
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
         "react-native": "*"
       }
     },
@@ -12957,6 +13084,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react-native": {
+      "version": "0.576.0",
+      "resolved": "https://registry.npmjs.org/lucide-react-native/-/lucide-react-native-0.576.0.tgz",
+      "integrity": "sha512-z38PwB7Rknhs1FrT1oMTp1MThnXpv//UH0usmhHAL8DrMoaBtKOKtRvdJOUleHmQZXMX8NcjgzOkelhCilUIlQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-native": "*",
+        "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -12997,6 +13134,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -13629,6 +13771,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -14570,6 +14723,20 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@expo-google-fonts/gabarito": "^0.4.2",
+    "@expo-google-fonts/graduate": "^0.4.1",
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
@@ -25,18 +27,21 @@
     "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.20",
+    "expo-font": "~14.0.11",
     "expo-image-manipulator": "~14.0.8",
     "expo-linking": "~8.0.11",
     "expo-localization": "~17.0.8",
     "expo-router": "~6.0.23",
     "expo-status-bar": "~3.0.9",
     "i18next": "^25.8.12",
+    "lucide-react-native": "^0.576.0",
     "react": "19.1.0",
     "react-i18next": "^16.5.4",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1",
     "react-native-url-polyfill": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Refs #56
Fait partie de #55

## Changements

- **lib/theme.ts** : design tokens complets (colors light/dark, spacing, radius, shadows, typography)
  - Primary: #FF7300 / primaryBg: #FFF8F0
  - Dark mode defaults
  - Semantic colors (expiry urgent/warning/safe)
- **app/_layout.tsx** : useFonts() avec Gabarito (400/500/600/700) + Graduate (400)
- **Nouvelles dépendances** : lucide-react-native, react-native-svg, @expo-google-fonts/gabarito, @expo-google-fonts/graduate, expo-font

## Test

- Lancer le dev build — les fonts doivent se charger sans erreur
- Le spinner de chargement doit apparaitre avec la couleur #FF7300