### PR TITLE
feat(design-system): atoms — Text, Badge, IconButton

### DIFF
--- a/components/atoms/Badge.tsx
+++ b/components/atoms/Badge.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from './Text';
+import { colors, radius, spacing, EXPIRY_BADGE_THRESHOLD_DAYS } from '@/lib/theme';
+
+type ColorScheme = 'light' | 'dark';
+
+interface BadgeProps {
+  daysLeft: number;
+  scheme?: ColorScheme;
+}
+
+function getExpiryLevel(daysLeft: number): 'urgent' | 'warning' | 'safe' {
+  if (daysLeft <= 1) return 'urgent';
+  if (daysLeft <= 7) return 'warning';
+  return 'safe';
+}
+
+export function Badge({ daysLeft, scheme = 'light' }: BadgeProps) {
+  if (daysLeft > EXPIRY_BADGE_THRESHOLD_DAYS) return null;
+
+  const level = getExpiryLevel(daysLeft);
+  const { text: textColor, bg } = colors[scheme].expiry[level];
+
+  const label = daysLeft <= 0 ? 'Exp.' : `${daysLeft}J`;
+
+  return (
+    <View style={[styles.container, { backgroundColor: bg }]}>
+      <Text
+        variant="quantity"
+        color={textColor}
+        style={styles.text}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderRadius: radius.pill,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+  },
+  text: {
+    fontSize: 10,
+    lineHeight: 14,
+  },
+});

--- a/components/atoms/IconButton.tsx
+++ b/components/atoms/IconButton.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Pressable, StyleSheet, ViewStyle } from 'react-native';
+import { LucideIcon } from 'lucide-react-native';
+import { colors, radius, spacing } from '@/lib/theme';
+
+type ColorScheme = 'light' | 'dark';
+
+interface IconButtonProps {
+  icon: LucideIcon;
+  active?: boolean;
+  onPress?: () => void;
+  size?: number;
+  scheme?: ColorScheme;
+  style?: ViewStyle;
+}
+
+export function IconButton({
+  icon: Icon,
+  active = false,
+  onPress,
+  size = 20,
+  scheme = 'light',
+  style,
+}: IconButtonProps) {
+  const { activeBg, activeColor, inactiveBg, inactiveColor } = colors[scheme].iconButton;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.container,
+        {
+          backgroundColor: active ? activeBg : inactiveBg,
+          opacity: pressed ? 0.7 : 1,
+        },
+        style,
+      ]}
+    >
+      <Icon
+        size={size}
+        color={active ? activeColor : inactiveColor}
+        strokeWidth={1.75}
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: 44,
+    height: 44,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.sm,
+  },
+});

--- a/components/atoms/Text.tsx
+++ b/components/atoms/Text.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Text as RNText, TextProps as RNTextProps, StyleSheet } from 'react-native';
+import { fontFamily, fontSize, colors } from '@/lib/theme';
+
+type Variant = 'h1' | 'h2' | 'h3' | 'body' | 'bodyMedium' | 'bodySemiBold' | 'label' | 'quantity';
+type ColorScheme = 'light' | 'dark';
+
+interface TextProps extends RNTextProps {
+  variant?: Variant;
+  color?: string;
+  scheme?: ColorScheme;
+}
+
+export function Text({ variant = 'body', color, scheme = 'light', style, ...props }: TextProps) {
+  return (
+    <RNText
+      style={[
+        styles.base,
+        styles[variant],
+        { color: color ?? colors[scheme].text.primary },
+        style,
+      ]}
+      {...props}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.md,
+  },
+  h1: {
+    fontFamily: fontFamily.bodyBold,
+    fontSize: fontSize.xxxl,
+  },
+  h2: {
+    fontFamily: fontFamily.bodyBold,
+    fontSize: fontSize.xxl,
+  },
+  h3: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.xl,
+  },
+  body: {
+    fontFamily: fontFamily.body,
+    fontSize: fontSize.md,
+  },
+  bodyMedium: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.md,
+  },
+  bodySemiBold: {
+    fontFamily: fontFamily.bodySemiBold,
+    fontSize: fontSize.md,
+  },
+  label: {
+    fontFamily: fontFamily.bodyMedium,
+    fontSize: fontSize.sm,
+  },
+  quantity: {
+    fontFamily: fontFamily.quantity,
+    fontSize: fontSize.sm,
+  },
+});

--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -1,0 +1,3 @@
+export { Text } from './Text';
+export { Badge } from './Badge';
+export { IconButton } from './IconButton';


### PR DESCRIPTION
Refs #57
Fait partie de #55

## Composants créés

- **Text** : wrapper avec 8 variants typographiques, fonts Gabarito/Graduate, support dark mode
- **Badge** : pill expiry 3 niveaux (urgent ≤1j / warning ≤7j / safe), invisible au-delà du seuil
- **IconButton** : 44×44px touch target, état actif/inactif, compatible Lucide icons
- **index.ts** : exports centralisés

## Usage

